### PR TITLE
Try using -> impl Responder<'r> instead

### DIFF
--- a/examples/guard.rs
+++ b/examples/guard.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, custom_derive)]
+#![feature(plugin, custom_derive, conservative_impl_trait)]
 #![plugin(rocket_codegen)]
 extern crate rocket;
 extern crate rocket_cors;
@@ -6,19 +6,20 @@ extern crate rocket_cors;
 use std::io::Cursor;
 
 use rocket::Response;
+use rocket::response::Responder;
 use rocket::http::Method;
-use rocket_cors::{Guard, AllowedOrigins, AllowedHeaders, Responder};
+use rocket_cors::{Guard, AllowedOrigins, AllowedHeaders};
 
 /// Using a `Responder` -- the usual way you would use this
 #[get("/")]
-fn responder(cors: Guard) -> Responder<&str> {
+fn responder(cors: Guard) -> impl Responder {
     cors.responder("Hello CORS!")
 }
 
 /// You need to define an OPTIONS route for preflight checks.
 /// These routes can just return the unit type `()`
 #[options("/")]
-fn responder_options(cors: Guard) -> Responder<()> {
+fn responder_options(cors: Guard) -> impl Responder {
     cors.responder(())
 }
 

--- a/examples/guard.rs
+++ b/examples/guard.rs
@@ -11,15 +11,21 @@ use rocket::http::Method;
 use rocket_cors::{Guard, AllowedOrigins, AllowedHeaders};
 
 /// Using a `Responder` -- the usual way you would use this
+///
+/// Unfortunately, you have to pepper the `'r` lifetime everywhere due to a compiler bug.
+/// See https://github.com/rust-lang/rust/issues/43380
 #[get("/")]
-fn responder(cors: Guard) -> impl Responder {
+fn responder<'r>(cors: Guard<'r>) -> impl Responder<'r> {
     cors.responder("Hello CORS!")
 }
 
 /// You need to define an OPTIONS route for preflight checks.
 /// These routes can just return the unit type `()`
+///
+/// Unfortunately, you have to pepper the `'r` lifetime everywhere due to a compiler bug.
+/// See https://github.com/rust-lang/rust/issues/43380
 #[options("/")]
-fn responder_options(cors: Guard) -> impl Responder {
+fn responder_options<'r>(cors: Guard<'r>) -> impl Responder<'r> {
     cors.responder(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@
 //! overwrite the previous CORS headers.
 //!
 //! ```rust,no_run
-//! #![feature(plugin, custom_derive)]
+//! #![feature(plugin, custom_derive, conservative_impl_trait)]
 //! #![plugin(rocket_codegen)]
 //! extern crate rocket;
 //! extern crate rocket_cors;
@@ -158,19 +158,26 @@
 //! use std::io::Cursor;
 //!
 //! use rocket::Response;
+//! use rocket::response::Responder;
 //! use rocket::http::Method;
-//! use rocket_cors::{Guard, AllowedOrigins, AllowedHeaders, Responder};
+//! use rocket_cors::{Guard, AllowedOrigins, AllowedHeaders};
 //!
 //! /// Using a `Responder` -- the usual way you would use this
+//! ///
+//! /// Unfortunately, you have to pepper the `'r` lifetime everywhere due to a compiler bug.
+//! /// See https://github.com/rust-lang/rust/issues/43380
 //! #[get("/")]
-//! fn responder(cors: Guard) -> Responder<&str> {
+//! fn responder<'r>(cors: Guard<'r>) -> impl Responder<'r> {
 //!     cors.responder("Hello CORS!")
 //! }
 //!
 //! /// You need to define an OPTIONS route for preflight checks.
 //! /// These routes can just return the unit type `()`
+//! ///
+//! /// Unfortunately, you have to pepper the `'r` lifetime everywhere due to a compiler bug.
+//! /// See https://github.com/rust-lang/rust/issues/43380
 //! #[options("/")]
-//! fn responder_options(cors: Guard) -> Responder<()> {
+//! fn responder_options<'r>(cors: Guard<'r>) -> impl Responder<'r> {
 //!     cors.responder(())
 //! }
 //!
@@ -204,7 +211,10 @@
 //!     };
 //!
 //!     rocket::ignite()
-//!         .mount("/", routes![responder, responder_options, response, response_options])
+//!         .mount(
+//!             "/",
+//!             routes![responder, responder_options, response, response_options],
+//!         )
 //!         .manage(options)
 //!         .launch();
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,6 +269,7 @@
 #![cfg_attr(test, feature(plugin, custom_derive))]
 #![cfg_attr(test, plugin(rocket_codegen))]
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
+#![feature(conservative_impl_trait)]
 
 #[macro_use]
 extern crate log;
@@ -1057,9 +1058,9 @@ impl<'r> Guard<'r> {
         }
     }
 
-    /// Consumes the Guard and return  a `Responder` that wraps a
+    /// Consumes the Guard and return  a `rocket:response::Responder` that wraps a
     /// provided `rocket:response::Responder` with CORS headers
-    pub fn responder<R: response::Responder<'r>>(self, responder: R) -> Responder<'r, R> {
+    pub fn responder<R: response::Responder<'r>>(self, responder: R) -> impl response::Responder<'r> {
         self.response.responder(responder)
     }
 

--- a/tests/guard.rs
+++ b/tests/guard.rs
@@ -1,6 +1,6 @@
 //! This crate tests using rocket_cors using the per-route handling with request guard
 
-#![feature(plugin, custom_derive)]
+#![feature(plugin, custom_derive, conservative_impl_trait)]
 #![plugin(rocket_codegen)]
 extern crate hyper;
 extern crate rocket;
@@ -12,14 +12,15 @@ use rocket::{Response, State};
 use rocket::http::Method;
 use rocket::http::{Header, Status};
 use rocket::local::Client;
+use rocket::response::Responder;
 
 #[options("/")]
-fn cors_options(cors: cors::Guard) -> cors::Responder<&str> {
+fn cors_options(cors: cors::Guard) -> impl Responder {
     cors.responder("")
 }
 
 #[get("/")]
-fn cors(cors: cors::Guard) -> cors::Responder<&str> {
+fn cors(cors: cors::Guard) -> impl Responder {
     cors.responder("Hello CORS")
 }
 
@@ -40,14 +41,14 @@ fn response(cors: cors::Guard) -> Response {
 /// `Responder` with String
 #[allow(unmounted_route)]
 #[get("/")]
-fn responder_string(cors: cors::Guard) -> cors::Responder<String> {
+fn responder_string(cors: cors::Guard) -> impl Responder {
     cors.responder("Hello CORS".to_string())
 }
 
 /// `Responder` with 'static ()
 #[allow(unmounted_route)]
 #[get("/")]
-fn responder_unit(cors: cors::Guard) -> cors::Responder<()> {
+fn responder_unit(cors: cors::Guard) -> impl Responder {
     cors.responder(())
 }
 
@@ -55,7 +56,7 @@ struct SomeState;
 /// Borrow `SomeState` from Rocket
 #[allow(unmounted_route)]
 #[get("/")]
-fn state<'r>(cors: cors::Guard<'r>, _state: State<'r, SomeState>) -> cors::Responder<'r, &'r str> {
+fn state<'r>(cors: cors::Guard<'r>, _state: State<'r, SomeState>) -> impl Responder<'r> {
     cors.responder("hmm")
 }
 

--- a/tests/guard.rs
+++ b/tests/guard.rs
@@ -15,12 +15,12 @@ use rocket::local::Client;
 use rocket::response::Responder;
 
 #[options("/")]
-fn cors_options(cors: cors::Guard) -> impl Responder {
+fn cors_options<'r>(cors: cors::Guard<'r>) -> impl Responder<'r> {
     cors.responder("")
 }
 
 #[get("/")]
-fn cors(cors: cors::Guard) -> impl Responder {
+fn cors<'r>(cors: cors::Guard<'r>) -> impl Responder<'r> {
     cors.responder("Hello CORS")
 }
 
@@ -41,14 +41,14 @@ fn response(cors: cors::Guard) -> Response {
 /// `Responder` with String
 #[allow(unmounted_route)]
 #[get("/")]
-fn responder_string(cors: cors::Guard) -> impl Responder {
+fn responder_string<'r>(cors: cors::Guard<'r>) -> impl Responder<'r> {
     cors.responder("Hello CORS".to_string())
 }
 
 /// `Responder` with 'static ()
 #[allow(unmounted_route)]
 #[get("/")]
-fn responder_unit(cors: cors::Guard) -> impl Responder {
+fn responder_unit<'r>(cors: cors::Guard<'r>) -> impl Responder<'r> {
     cors.responder(())
 }
 


### PR DESCRIPTION
But unfortunately, the lifetime `'r` now has to proliferate everywhere.

There is currently a [compiler panic](https://github.com/rust-lang/rust/issues/43380) without the lifetime, but I am not sure that even if the panic is fixed, we are allowed to leave the lifetime out.

This is because lifetimes are _elided_ in Rust, not inferred. 

So this might never get merged.

(The truth is I would rather not expose the `Responder` type to public.)