### PR TITLE
fixed rocket_cors version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ work, but they are subject to the minimum that Rocket sets.
 Add the following to Cargo.toml:
 
 ```toml
-rocket_cors = "0.3.0"
+rocket_cors = "0.2.3"
 ```
 
 To use the latest `master` branch, for example:


### PR DESCRIPTION
Hi, unless I'm mistaken I think the rocket_cors version in the readme is wrong!
Thanks for the crate