### PR TITLE
Refactor Origins to better support additional use cases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ travis-ci = { repository = "lawliet89/rocket_cors" }
 default = ["serialization"]
 
 # Serialization and deserialization support for settings
-serialization = ["serde", "serde_derive", "unicase_serde", "url_serde"]
+serialization = ["serde", "serde_derive", "unicase_serde"]
 
 [dependencies]
 rocket = "0.4.0"
@@ -30,7 +30,6 @@ url = "1.7.2"
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 unicase_serde = { version = "0.1.0", optional = true }
-url_serde = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 hyper = "0.10"

--- a/examples/fairing.rs
+++ b/examples/fairing.rs
@@ -12,8 +12,7 @@ fn cors<'a>() -> &'a str {
 }
 
 fn main() -> Result<(), Error> {
-    let (allowed_origins, failed_origins) = AllowedOrigins::some(&["https://www.acme.com"]);
-    assert!(failed_origins.is_empty());
+    let allowed_origins = AllowedOrigins::some(&["https://www.acme.com"]);
 
     // You can also deserialize this
     let cors = rocket_cors::CorsOptions {

--- a/examples/guard.rs
+++ b/examples/guard.rs
@@ -36,8 +36,7 @@ fn manual(cors: Guard<'_>) -> Responder<'_, &str> {
 }
 
 fn main() -> Result<(), Error> {
-    let (allowed_origins, failed_origins) = AllowedOrigins::some(&["https://www.acme.com"]);
-    assert!(failed_origins.is_empty());
+    let allowed_origins = AllowedOrigins::some(&["https://www.acme.com"]);
 
     // You can also deserialize this
     let cors = rocket_cors::CorsOptions {

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -13,8 +13,7 @@ fn main() {
     // The default demonstrates the "All" serialization of several of the settings
     let default: CorsOptions = Default::default();
 
-    let (allowed_origins, failed_origins) = AllowedOrigins::some(&["https://www.acme.com"]);
-    assert!(failed_origins.is_empty());
+    let allowed_origins = AllowedOrigins::some(&["https://www.acme.com"]);
 
     let options = cors::CorsOptions {
         allowed_origins: allowed_origins,

--- a/examples/manual.rs
+++ b/examples/manual.rs
@@ -59,8 +59,7 @@ fn owned_options<'r>() -> impl Responder<'r> {
 }
 
 fn cors_options() -> CorsOptions {
-    let (allowed_origins, failed_origins) = AllowedOrigins::some(&["https://www.acme.com"]);
-    assert!(failed_origins.is_empty());
+    let allowed_origins = AllowedOrigins::some(&["https://www.acme.com"]);
 
     // You can also deserialize this
     rocket_cors::CorsOptions {

--- a/examples/mix.rs
+++ b/examples/mix.rs
@@ -36,8 +36,7 @@ fn ping_options<'r>() -> impl Responder<'r> {
 
 /// Returns the "application wide" Cors struct
 fn cors_options() -> CorsOptions {
-    let (allowed_origins, failed_origins) = AllowedOrigins::some(&["https://www.acme.com"]);
-    assert!(failed_origins.is_empty());
+    let allowed_origins = AllowedOrigins::some(&["https://www.acme.com"]);
 
     // You can also deserialize this
     rocket_cors::CorsOptions {

--- a/src/fairing.rs
+++ b/src/fairing.rs
@@ -53,7 +53,7 @@ fn on_response_wrapper(
             // Not a CORS request
             return Ok(());
         }
-        Some(origin) => crate::to_origin(origin)?,
+        Some(origin) => origin,
     };
 
     let result = request.local_cache(|| unreachable!("This should not be executed so late"));

--- a/src/fairing.rs
+++ b/src/fairing.rs
@@ -53,7 +53,7 @@ fn on_response_wrapper(
             // Not a CORS request
             return Ok(());
         }
-        Some(origin) => origin,
+        Some(origin) => crate::to_origin(origin)?,
     };
 
     let result = request.local_cache(|| unreachable!("This should not be executed so late"));
@@ -140,8 +140,7 @@ mod tests {
     const CORS_ROOT: &'static str = "/my_cors";
 
     fn make_cors_options() -> Cors {
-        let (allowed_origins, failed_origins) = AllowedOrigins::some(&["https://www.acme.com"]);
-        assert!(failed_origins.is_empty());
+        let allowed_origins = AllowedOrigins::some(&["https://www.acme.com"]);
 
         CorsOptions {
             allowed_origins,

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -216,7 +216,10 @@ mod tests {
         let outcome: request::Outcome<Origin, crate::Error> =
             FromRequest::from_request(request.inner());
         let parsed_header = assert_matches!(outcome, Outcome::Success(s), s);
-        assert_eq!("https://www.example.com", parsed_header.ascii_serialization());
+        assert_eq!(
+            "https://www.example.com",
+            parsed_header.ascii_serialization()
+        );
     }
 
     #[test]

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -11,12 +11,9 @@ use rocket::{self, Outcome};
 #[cfg(feature = "serialization")]
 use serde_derive::{Deserialize, Serialize};
 use unicase::UniCase;
-use url;
 
 #[cfg(feature = "serialization")]
 use unicase_serde;
-#[cfg(feature = "serialization")]
-use url_serde;
 
 /// A case insensitive header name
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
@@ -62,54 +59,55 @@ impl FromStr for HeaderFieldName {
 /// A set of case insensitive header names
 pub type HeaderFieldNamesSet = HashSet<HeaderFieldName>;
 
-/// A wrapped `url::Url` to allow for deserialization
+/// The `Origin` request header used in CORS
+///
+/// You can use this as a rocket [Request Guard](https://rocket.rs/guide/requests/#request-guards)
+/// to ensure that `Origin` is passed in correctly.
 #[derive(Eq, PartialEq, Clone, Hash, Debug)]
 #[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
-pub struct Url(#[cfg_attr(feature = "serialization", serde(with = "url_serde"))] url::Url);
+pub struct Origin(pub String);
 
-impl fmt::Display for Url {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
+impl FromStr for Origin {
+    type Err = !;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        Ok(Origin(input.to_string()))
     }
 }
 
-impl Deref for Url {
-    type Target = url::Url;
+impl Deref for Origin {
+    type Target = str;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl FromStr for Url {
-    type Err = url::ParseError;
-
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
-        let url = url::Url::from_str(input)?;
-        Ok(Url(url))
+impl AsRef<str> for Origin {
+    fn as_ref(&self) -> &str {
+        self
     }
 }
 
-impl<'a, 'r> FromRequest<'a, 'r> for Url {
+impl fmt::Display for Origin {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.as_ref().fmt(f)
+    }
+}
+
+impl<'a, 'r> FromRequest<'a, 'r> for Origin {
     type Error = crate::Error;
 
     fn from_request(request: &'a rocket::Request<'r>) -> request::Outcome<Self, crate::Error> {
         match request.headers().get_one("Origin") {
-            Some(origin) => match Self::from_str(origin) {
-                Ok(origin) => Outcome::Success(origin),
-                Err(e) => Outcome::Failure((Status::BadRequest, crate::Error::BadOrigin(e))),
-            },
+            Some(origin) => {
+                let Ok(origin) = Self::from_str(origin);
+                Outcome::Success(origin)
+            }
             None => Outcome::Forward(()),
         }
     }
 }
-
-/// The `Origin` request header used in CORS
-///
-/// You can use this as a rocket [Request Guard](https://rocket.rs/guide/requests/#request-guards)
-/// to ensure that `Origin` is passed in correctly.
-pub type Origin = Url;
-
 /// The `Access-Control-Request-Method` request header
 ///
 /// You can use this as a rocket [Request Guard](https://rocket.rs/guide/requests/#request-guards)
@@ -201,17 +199,17 @@ mod tests {
     #[test]
     fn origin_header_conversion() {
         let url = "https://foo.bar.xyz";
-        let parsed = not_err!(Origin::from_str(url));
-        let expected = not_err!(Url::from_str(url));
-        assert_eq!(parsed, expected);
+        let Ok(parsed) = Origin::from_str(url);
+        assert_eq!(parsed.as_ref(), url);
 
         let url = "https://foo.bar.xyz/path/somewhere"; // this should never really be used
-        let parsed = not_err!(Origin::from_str(url));
-        let expected = not_err!(Url::from_str(url));
-        assert_eq!(parsed, expected);
+        let Ok(parsed) = Origin::from_str(url);
+        assert_eq!(parsed.as_ref(), url);
 
+        // Validation is not done now
         let url = "invalid_url";
-        let _ = is_err!(Origin::from_str(url));
+        let Ok(parsed) = Origin::from_str(url);
+        assert_eq!(parsed.as_ref(), url);
     }
 
     #[test]
@@ -225,7 +223,7 @@ mod tests {
         let outcome: request::Outcome<Origin, crate::Error> =
             FromRequest::from_request(request.inner());
         let parsed_header = assert_matches!(outcome, Outcome::Success(s), s);
-        assert_eq!("https://www.example.com/", parsed_header.as_str());
+        assert_eq!("https://www.example.com", parsed_header.as_ref());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -714,7 +714,7 @@ pub struct CorsOptions {
     ///
     /// Defaults to `All`.
     #[cfg_attr(feature = "serialization", serde(default))]
-    pub allowed_headers: AllOrSome<HashSet<HeaderFieldName>>,
+    pub allowed_headers: AllowedHeaders,
     /// Allows users to make authenticated requests.
     /// If true, injects the `Access-Control-Allow-Credentials` header in responses.
     /// This allows cookies and credentials to be submitted across domains.
@@ -1314,7 +1314,7 @@ fn validate(options: &Cors, request: &Request<'_>) -> Result<ValidationResult, E
 /// Useful for pre-flight and during requests
 fn validate_origin(
     origin: &Origin,
-    allowed_origins: &AllOrSome<HashSet<Url>>,
+    allowed_origins: &AllowedOrigins,
 ) -> Result<(), Error> {
     match *allowed_origins {
         // Always matching is acceptable since the list of origins can be unbounded.
@@ -1329,7 +1329,7 @@ fn validate_origin(
 /// Validate allowed methods
 fn validate_allowed_method(
     method: &AccessControlRequestMethod,
-    allowed_methods: &HashSet<Method>,
+    allowed_methods: &AllowedMethods,
 ) -> Result<(), Error> {
     let &AccessControlRequestMethod(ref request_method) = method;
     if !allowed_methods.iter().any(|m| m == request_method) {
@@ -1343,7 +1343,7 @@ fn validate_allowed_method(
 /// Validate allowed headers
 fn validate_allowed_headers(
     headers: &AccessControlRequestHeaders,
-    allowed_headers: &AllOrSome<HashSet<HeaderFieldName>>,
+    allowed_headers: &AllowedHeaders,
 ) -> Result<(), Error> {
     let &AccessControlRequestHeaders(ref headers) = headers;
 

--- a/tests/fairing.rs
+++ b/tests/fairing.rs
@@ -22,8 +22,7 @@ fn panicking_route() {
 }
 
 fn make_cors() -> Cors {
-    let (allowed_origins, failed_origins) = AllowedOrigins::some(&["https://www.acme.com"]);
-    assert!(failed_origins.is_empty());
+    let allowed_origins = AllowedOrigins::some(&["https://www.acme.com"]);
 
     CorsOptions {
         allowed_origins: allowed_origins,

--- a/tests/guard.rs
+++ b/tests/guard.rs
@@ -60,8 +60,7 @@ fn state<'r>(cors: cors::Guard<'r>, _state: State<'r, SomeState>) -> cors::Respo
 }
 
 fn make_cors() -> cors::Cors {
-    let (allowed_origins, failed_origins) = cors::AllowedOrigins::some(&["https://www.acme.com"]);
-    assert!(failed_origins.is_empty());
+    let allowed_origins = cors::AllowedOrigins::some(&["https://www.acme.com"]);
 
     cors::CorsOptions {
         allowed_origins: allowed_origins,

--- a/tests/headers.rs
+++ b/tests/headers.rs
@@ -55,7 +55,7 @@ fn request_headers_round_trip_smoke_test() {
         .body()
         .and_then(|body| body.into_string())
         .expect("Non-empty body");
-    let expected_body = r#"https://foo.bar.xyz/
+    let expected_body = r#"https://foo.bar.xyz
 GET
 X-Ping, accept-language"#;
     assert_eq!(expected_body, body_str);

--- a/tests/manual.rs
+++ b/tests/manual.rs
@@ -66,8 +66,7 @@ fn borrow<'r>(options: State<'r, Cors>, test_state: State<'r, TestState>) -> imp
 }
 
 fn make_cors_options() -> CorsOptions {
-    let (allowed_origins, failed_origins) = AllowedOrigins::some(&["https://www.acme.com"]);
-    assert!(failed_origins.is_empty());
+    let allowed_origins = AllowedOrigins::some(&["https://www.acme.com"]);
 
     CorsOptions {
         allowed_origins: allowed_origins,
@@ -79,8 +78,7 @@ fn make_cors_options() -> CorsOptions {
 }
 
 fn make_different_cors_options() -> CorsOptions {
-    let (allowed_origins, failed_origins) = AllowedOrigins::some(&["https://www.example.com"]);
-    assert!(failed_origins.is_empty());
+    let allowed_origins = AllowedOrigins::some(&["https://www.example.com"]);
 
     CorsOptions {
         allowed_origins: allowed_origins,

--- a/tests/mix.rs
+++ b/tests/mix.rs
@@ -40,8 +40,7 @@ fn ping_options<'r>() -> impl Responder<'r> {
 
 /// Returns the "application wide" Cors struct
 fn cors_options() -> CorsOptions {
-    let (allowed_origins, failed_origins) = AllowedOrigins::some(&["https://www.acme.com"]);
-    assert!(failed_origins.is_empty());
+    let allowed_origins = AllowedOrigins::some(&["https://www.acme.com"]);
 
     // You can also deserialize this
     rocket_cors::CorsOptions {


### PR DESCRIPTION
#31 being the primary motivation. Also to support `null`... although is there a point?

Remaining questions/TODOs:

- Support Regex
- Make the `Cors` struct be less "dumb" in being essentially a copy of `CorsOptions`
- How to support "non-standard" schemas that the URI crate doesn't support? Can just throw everything to regex?