### PR TITLE
Disable default features on Rocket

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serialization = ["serde", "serde_derive", "unicase_serde"]
 
 [dependencies]
 regex = "1.1"
-rocket = "0.4.0"
+rocket = { version = "0.4.0", default-features = false }
 log = "0.3"
 unicase = "2.0"
 url = "1.7.2"


### PR DESCRIPTION
This change should allow using rocket_cors with Rocket's async branch, which has (indirectly) updated its dependency on ring. Since rocket_cors doesn't use cookies anywhere, this change effectively does nothing but increase compatibility.