### PR TITLE
Fix build issues for Rocket 0.4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ sudo: false
 language: rust
 rust:
   - nightly
-  # Minimum Rust set by Rocket
-  - nightly-2019-04-05
+  - nightly-2019-04-11 # Minimum supported
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: rust
 rust:
   - nightly
-  - nightly-2019-04-11 # Minimum supported
+  - nightly-2019-04-18 # Minimum supported
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: rust
 rust:
   - nightly
-  - nightly-2019-04-18 # Minimum supported
+  - nightly-2019-05-21 # Minimum supported
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: rust
 rust:
   - nightly
   # Minimum Rust set by Rocket
-  - nightly-2018-11-25
+  - nightly-2019-04-05
 branches:
   only:
   - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 0.5.1 (2019-11-13)
+
+There are no new features.
+
+- Fix build issues with Rocket 0.4.2
+- Fix clippy lints with latest nightly
+
 ## <a name="0.5.0"></a>0.5.0 (2019-05-27)
 
 There is no change since `0.5.0-beta1`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocket_cors"
-version = "0.5.0"
+version = "0.5.1"
 license = "MIT/Apache-2.0"
 authors = ["Yong Wen Chua <me@yongwen.xyz>"]
 description = "Cross-origin resource sharing (CORS) for Rocket.rs applications"
@@ -22,7 +22,7 @@ serialization = ["serde", "serde_derive", "unicase_serde"]
 
 [dependencies]
 regex = "1.1"
-rocket = { version = "0.4.0", default-features = false }
+rocket = { version = "0.4.2", default-features = false }
 log = "0.3"
 unicase = "2.0"
 url = "1.7.2"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Cross-origin resource sharing (CORS) for [Rocket](https://rocket.rs/) applicatio
 
 If you are using Rocket 0.3, use the `0.3.0` version of this crate.
 
+There is a minimum version of Rust nightly required. This is usually higher than whatever
+Rocket requires plus more if the dependent crates require other features.
+
 ### Nightly Rust
 
 Rocket requires nightly Rust. You should probably install Rust with

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ work, but they are subject to the minimum that Rocket sets.
 Add the following to Cargo.toml:
 
 ```toml
-rocket_cors = "0.5.0"
+rocket_cors = "0.5.1"
 ```
 
 To use the latest `master` branch, for example:

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -328,7 +328,7 @@ mod tests {
         let headers = ["foo", "bar", "baz"];
         let parsed_headers = not_err!(AccessControlRequestHeaders::from_str(&headers.join(", ")));
         let expected_headers: HeaderFieldNamesSet =
-            headers.iter().map(|s| s.to_string().into()).collect();
+            headers.iter().map(|s| (*s).to_string().into()).collect();
         let AccessControlRequestHeaders(actual_headers) = parsed_headers;
         assert_eq!(actual_headers, expected_headers);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ might work, but they are subject to the minimum that Rocket sets.
 Add the following to Cargo.toml:
 
 ```toml
-rocket_cors = "0.5.0-beta-2"
+rocket_cors = "0.5.1-beta-2"
 ```
 
 To use the latest `master` branch, for example:
@@ -45,7 +45,7 @@ the [`CorsOptions`] struct that is described below. If you would like to disable
 change your `Cargo.toml` to:
 
 ```toml
-rocket_cors = { version = "0.5.0", default-features = false }
+rocket_cors = { version = "0.5.1", default-features = false }
 ```
 
 ## Usage
@@ -258,7 +258,6 @@ See the [example](https://github.com/lawliet89/rocket_cors/blob/master/examples/
     while_true
 )]
 #![allow(
-    legacy_directory_ownership,
     missing_copy_implementations,
     missing_debug_implementations,
     unknown_lints,
@@ -812,12 +811,12 @@ impl ParsedAllowedOrigins {
             exact.into_iter().partition(|(_, url)| url.is_tuple());
 
         if !opaque.is_empty() {
-            Err(Error::OpaqueAllowedOrigin(
+            return Err(Error::OpaqueAllowedOrigin(
                 opaque
                     .into_iter()
                     .map(|(original, _)| original.to_string())
                     .collect(),
-            ))?
+            ));
         }
 
         let exact = tuple.into_iter().map(|(_, url)| url).collect();
@@ -907,7 +906,7 @@ pub type AllowedHeaders = AllOrSome<HashSet<HeaderFieldName>>;
 impl AllowedHeaders {
     /// Allow some headers
     pub fn some(headers: &[&str]) -> Self {
-        AllOrSome::Some(headers.iter().map(|s| s.to_string().into()).collect())
+        AllOrSome::Some(headers.iter().map(|s| (*s).to_string().into()).collect())
     }
 
     /// Allows all headers
@@ -1143,7 +1142,7 @@ impl CorsOptions {
     /// Validates if any of the settings are disallowed, incorrect, or illegal
     pub fn validate(&self) -> Result<(), Error> {
         if self.allowed_origins.is_all() && self.send_wildcard && self.allow_credentials {
-            Err(Error::CredentialsWithWildcardOrigin)?;
+            return Err(Error::CredentialsWithWildcardOrigin);
         }
 
         Ok(())
@@ -1296,7 +1295,7 @@ impl Response {
     /// Consumes the CORS, set expose_headers to
     /// passed headers and returns changed CORS
     fn exposed_headers(mut self, headers: &[&str]) -> Self {
-        self.expose_headers = headers.iter().map(|s| s.to_string().into()).collect();
+        self.expose_headers = headers.iter().map(|s| (*s).to_string().into()).collect();
         self
     }
 
@@ -1317,7 +1316,7 @@ impl Response {
     /// Consumes the CORS, set allow_headers to
     /// passed headers and returns changed CORS
     fn headers(mut self, headers: &[&str]) -> Self {
-        self.allow_headers = headers.iter().map(|s| s.to_string().into()).collect();
+        self.allow_headers = headers.iter().map(|s| (*s).to_string().into()).collect();
         self
     }
 
@@ -1680,7 +1679,7 @@ fn validate_allowed_method(
 ) -> Result<(), Error> {
     let &AccessControlRequestMethod(ref request_method) = method;
     if !allowed_methods.iter().any(|m| m == request_method) {
-        Err(Error::MethodNotAllowed(method.0.to_string()))?
+        return Err(Error::MethodNotAllowed(method.0.to_string()));
     }
 
     // TODO: Subset to route? Or just the method requested for?
@@ -1698,7 +1697,7 @@ fn validate_allowed_headers(
         AllOrSome::All => Ok(()),
         AllOrSome::Some(ref allowed_headers) => {
             if !headers.is_empty() && !headers.is_subset(allowed_headers) {
-                Err(Error::HeadersNotAllowed)?
+                return Err(Error::HeadersNotAllowed);
             }
             Ok(())
         }
@@ -1991,7 +1990,7 @@ mod tests {
             allow_credentials: true,
             expose_headers: ["Content-Type", "X-Custom"]
                 .iter()
-                .map(|s| s.to_string())
+                .map(|s| (*s).to_string())
                 .collect(),
             ..Default::default()
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ might work, but they are subject to the minimum that Rocket sets.
 Add the following to Cargo.toml:
 
 ```toml
-rocket_cors = "0.5.1-beta-2"
+rocket_cors = "0.5.1"
 ```
 
 To use the latest `master` branch, for example:


### PR DESCRIPTION
- Fix clippy lints
- Bump minimum Rust version beyond Rocket required for
  - `std::mem::MaybeUninit`
  - `alloc` crate