### PR TITLE
Use async version from rocket's master branch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       matrix:
         rust:
+          - stable
           - nightly
-          - nightly-2019-05-21  # MSRV
         os:
           - ubuntu-latest
           - windows-latest
@@ -21,6 +21,8 @@ jobs:
         cargo_flags:
           - "--all-features"
           - "--no-default-features"
+
+      fail-fast: false
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -34,9 +36,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
           components: rustfmt, clippy
-
-      - name: Remove Rust Toolchain file
-        run: rm rust-toolchain
 
       - uses: actions-rs/cargo@v1
         name: Clippy Lint

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serialization = ["serde", "serde_derive", "unicase_serde"]
 
 [dependencies]
 regex = "1.1"
-rocket = { version = "0.4.2", default-features = false }
+rocket = { git="https://github.com/SergioBenitez/Rocket.git", default-features = false }
 log = "0.4"
 unicase = "2.0"
 url = "2.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ serde_derive = { version = "1.0", optional = true }
 unicase_serde = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
-hyper = "0.10"
 serde_json = "1.0"
 serde_test = "1.0"
 

--- a/examples/fairing.rs
+++ b/examples/fairing.rs
@@ -1,7 +1,4 @@
 #![feature(proc_macro_hygiene, decl_macro)]
-use rocket;
-use rocket_cors;
-
 use std::error::Error;
 
 use rocket::http::Method;

--- a/examples/fairing.rs
+++ b/examples/fairing.rs
@@ -1,4 +1,3 @@
-#![feature(proc_macro_hygiene, decl_macro)]
 use std::error::Error;
 
 use rocket::http::Method;

--- a/examples/fairing.rs
+++ b/examples/fairing.rs
@@ -2,16 +2,19 @@
 use rocket;
 use rocket_cors;
 
+use std::error::Error;
+
 use rocket::http::Method;
 use rocket::{get, routes};
-use rocket_cors::{AllowedHeaders, AllowedOrigins, Error};
+use rocket_cors::{AllowedHeaders, AllowedOrigins};
 
 #[get("/")]
 fn cors<'a>() -> &'a str {
     "Hello CORS"
 }
 
-fn main() -> Result<(), Error> {
+#[rocket::main]
+async fn main() -> Result<(), Box<dyn Error>> {
     let allowed_origins = AllowedOrigins::some_exact(&["https://www.acme.com"]);
 
     // You can also deserialize this
@@ -27,7 +30,8 @@ fn main() -> Result<(), Error> {
     rocket::ignite()
         .mount("/", routes![cors])
         .attach(cors)
-        .launch();
+        .launch()
+        .await?;
 
     Ok(())
 }

--- a/examples/guard.rs
+++ b/examples/guard.rs
@@ -1,7 +1,4 @@
 #![feature(proc_macro_hygiene, decl_macro)]
-use rocket;
-use rocket_cors;
-
 use std::error::Error;
 use std::io::Cursor;
 

--- a/examples/guard.rs
+++ b/examples/guard.rs
@@ -1,4 +1,3 @@
-#![feature(proc_macro_hygiene, decl_macro)]
 use std::error::Error;
 use std::io::Cursor;
 

--- a/examples/guard.rs
+++ b/examples/guard.rs
@@ -2,16 +2,17 @@
 use rocket;
 use rocket_cors;
 
+use std::error::Error;
 use std::io::Cursor;
 
 use rocket::http::Method;
 use rocket::Response;
 use rocket::{get, options, routes};
-use rocket_cors::{AllowedHeaders, AllowedOrigins, Error, Guard, Responder};
+use rocket_cors::{AllowedHeaders, AllowedOrigins, Guard, Responder};
 
 /// Using a `Responder` -- the usual way you would use this
 #[get("/")]
-fn responder(cors: Guard<'_>) -> Responder<'_, &str> {
+fn responder(cors: Guard<'_>) -> Responder<'_, '_, &str> {
     cors.responder("Hello CORS!")
 }
 
@@ -19,23 +20,25 @@ fn responder(cors: Guard<'_>) -> Responder<'_, &str> {
 #[get("/response")]
 fn response(cors: Guard<'_>) -> Response<'_> {
     let mut response = Response::new();
-    response.set_sized_body(Cursor::new("Hello CORS!"));
+    let body = "Hello CORS!";
+    response.set_sized_body(body.len(), Cursor::new(body));
     cors.response(response)
 }
 
 /// Manually mount an OPTIONS route for your own handling
 #[options("/manual")]
-fn manual_options(cors: Guard<'_>) -> Responder<'_, &str> {
+fn manual_options(cors: Guard<'_>) -> Responder<'_, '_, &str> {
     cors.responder("Manual OPTIONS preflight handling")
 }
 
 /// Manually mount an OPTIONS route for your own handling
 #[get("/manual")]
-fn manual(cors: Guard<'_>) -> Responder<'_, &str> {
+fn manual(cors: Guard<'_>) -> Responder<'_, '_, &str> {
     cors.responder("Manual OPTIONS preflight handling")
 }
 
-fn main() -> Result<(), Error> {
+#[rocket::main]
+async fn main() -> Result<(), Box<dyn Error>> {
     let allowed_origins = AllowedOrigins::some_exact(&["https://www.acme.com"]);
 
     // You can also deserialize this
@@ -55,7 +58,8 @@ fn main() -> Result<(), Error> {
         // You can also manually mount an OPTIONS route that will be used instead
         .mount("/", routes![manual, manual_options])
         .manage(cors)
-        .launch();
+        .launch()
+        .await?;
 
     Ok(())
 }

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -4,7 +4,6 @@
 #![feature(proc_macro_hygiene, decl_macro)]
 
 use rocket_cors as cors;
-use serde_json;
 
 use crate::cors::{AllowedHeaders, AllowedOrigins, CorsOptions};
 use rocket::http::Method;

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -1,8 +1,6 @@
 //! This example is to demonstrate the JSON serialization and deserialization of the Cors settings
 //!
 //! Note: This requires the `serialization` feature which is enabled by default.
-#![feature(proc_macro_hygiene, decl_macro)]
-
 use rocket_cors as cors;
 
 use crate::cors::{AllowedHeaders, AllowedOrigins, CorsOptions};

--- a/examples/manual.rs
+++ b/examples/manual.rs
@@ -1,7 +1,4 @@
 #![feature(proc_macro_hygiene, decl_macro)]
-use rocket;
-use rocket_cors;
-
 use std::io::Cursor;
 
 use rocket::error::Error;

--- a/examples/manual.rs
+++ b/examples/manual.rs
@@ -1,4 +1,3 @@
-#![feature(proc_macro_hygiene, decl_macro)]
 use std::io::Cursor;
 
 use rocket::error::Error;

--- a/examples/manual.rs
+++ b/examples/manual.rs
@@ -4,6 +4,7 @@ use rocket_cors;
 
 use std::io::Cursor;
 
+use rocket::error::Error;
 use rocket::http::Method;
 use rocket::response::Responder;
 use rocket::{get, options, routes, Response, State};
@@ -17,7 +18,7 @@ use rocket_cors::{AllowedHeaders, AllowedOrigins, Cors, CorsOptions};
 /// Note that the `'r` lifetime annotation is not requred here because `State` borrows with lifetime
 /// `'r` and so does `Responder`!
 #[get("/")]
-fn borrowed(options: State<'_, Cors>) -> impl Responder<'_> {
+fn borrowed(options: State<'_, Cors>) -> impl Responder<'_, '_> {
     options
         .inner()
         .respond_borrowed(|guard| guard.responder("Hello CORS"))
@@ -27,9 +28,10 @@ fn borrowed(options: State<'_, Cors>) -> impl Responder<'_> {
 /// Note that the `'r` lifetime annotation is not requred here because `State` borrows with lifetime
 /// `'r` and so does `Responder`!
 #[get("/response")]
-fn response(options: State<'_, Cors>) -> impl Responder<'_> {
+fn response(options: State<'_, Cors>) -> impl Responder<'_, '_> {
     let mut response = Response::new();
-    response.set_sized_body(Cursor::new("Hello CORS!"));
+    let body = "Hello CORS!";
+    response.set_sized_body(body.len(), Cursor::new(body));
 
     options
         .inner()
@@ -43,7 +45,7 @@ fn response(options: State<'_, Cors>) -> impl Responder<'_> {
 /// when the settings you want to use for a route is not the same as the rest of the application
 /// (which you might have put in Rocket's state).
 #[get("/owned")]
-fn owned<'r>() -> impl Responder<'r> {
+fn owned<'r, 'o: 'r>() -> impl Responder<'r, 'o> {
     let options = cors_options().to_cors()?;
     options.respond_owned(|guard| guard.responder("Hello CORS"))
 }
@@ -53,7 +55,7 @@ fn owned<'r>() -> impl Responder<'r> {
 /// These routes can just return the unit type `()`
 /// Note that the `'r` lifetime is needed because the compiler cannot elide anything.
 #[options("/owned")]
-fn owned_options<'r>() -> impl Responder<'r> {
+fn owned_options<'r, 'o: 'r>() -> impl Responder<'r, 'o> {
     let options = cors_options().to_cors()?;
     options.respond_owned(|guard| guard.responder(()))
 }
@@ -71,10 +73,12 @@ fn cors_options() -> CorsOptions {
     }
 }
 
-fn main() {
+#[rocket::main]
+async fn main() -> Result<(), Error> {
     rocket::ignite()
         .mount("/", routes![borrowed, response, owned, owned_options,])
         .mount("/", rocket_cors::catch_all_options_routes()) // mount the catch all routes
         .manage(cors_options().to_cors().expect("To not fail"))
-        .launch();
+        .launch()
+        .await
 }

--- a/examples/mix.rs
+++ b/examples/mix.rs
@@ -3,7 +3,6 @@
 //! In this example, you typically have an application wide `Cors` struct except for one specific
 //! `ping` route that you want to allow all Origins to access.
 
-#![feature(proc_macro_hygiene, decl_macro)]
 use rocket::error::Error;
 use rocket::http::Method;
 use rocket::response::Responder;

--- a/examples/mix.rs
+++ b/examples/mix.rs
@@ -4,9 +4,6 @@
 //! `ping` route that you want to allow all Origins to access.
 
 #![feature(proc_macro_hygiene, decl_macro)]
-use rocket;
-use rocket_cors;
-
 use rocket::error::Error;
 use rocket::http::Method;
 use rocket::response::Responder;

--- a/examples/mix.rs
+++ b/examples/mix.rs
@@ -7,6 +7,7 @@
 use rocket;
 use rocket_cors;
 
+use rocket::error::Error;
 use rocket::http::Method;
 use rocket::response::Responder;
 use rocket::{get, options, routes};
@@ -14,13 +15,13 @@ use rocket_cors::{AllowedHeaders, AllowedOrigins, CorsOptions, Guard};
 
 /// The "usual" app route
 #[get("/")]
-fn app(cors: Guard<'_>) -> rocket_cors::Responder<'_, &str> {
+fn app(cors: Guard<'_>) -> rocket_cors::Responder<'_, '_, &str> {
     cors.responder("Hello CORS!")
 }
 
 /// The special "ping" route
 #[get("/ping")]
-fn ping<'r>() -> impl Responder<'r> {
+fn ping<'r, 'o: 'r>() -> impl Responder<'r, 'o> {
     let cors = cors_options_all().to_cors()?;
     cors.respond_owned(|guard| guard.responder("Pong!"))
 }
@@ -29,7 +30,7 @@ fn ping<'r>() -> impl Responder<'r> {
 /// that is not in Rocket's managed state.
 /// These routes can just return the unit type `()`
 #[options("/ping")]
-fn ping_options<'r>() -> impl Responder<'r> {
+fn ping_options<'r, 'o: 'r>() -> impl Responder<'r, 'o> {
     let cors = cors_options_all().to_cors()?;
     cors.respond_owned(|guard| guard.responder(()))
 }
@@ -57,10 +58,12 @@ fn cors_options_all() -> CorsOptions {
     Default::default()
 }
 
-fn main() {
+#[rocket::main]
+async fn main() -> Result<(), Error> {
     rocket::ignite()
         .mount("/", routes![app, ping, ping_options,])
         .mount("/", rocket_cors::catch_all_options_routes()) // mount the catch all routes
         .manage(cors_options().to_cors().expect("To not fail"))
-        .launch();
+        .launch()
+        .await
 }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,0 @@
-nightly

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -12,9 +12,6 @@ use rocket::{self, outcome::Outcome};
 use serde_derive::{Deserialize, Serialize};
 use unicase::UniCase;
 
-#[cfg(feature = "serialization")]
-use unicase_serde;
-
 /// A case insensitive header name
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
@@ -255,10 +252,15 @@ impl<'a, 'r> FromRequest<'a, 'r> for AccessControlRequestHeaders {
 mod tests {
     use std::str::FromStr;
 
-    use rocket;
     use rocket::http::hyper;
     use rocket::http::Header;
     use rocket::local::blocking::Client;
+
+    static ORIGIN: hyper::HeaderName = hyper::header::ORIGIN;
+    static ACCESS_CONTROL_REQUEST_METHOD: hyper::HeaderName =
+        hyper::header::ACCESS_CONTROL_REQUEST_METHOD;
+    static ACCESS_CONTROL_REQUEST_HEADERS: hyper::HeaderName =
+        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS;
 
     use super::*;
 
@@ -328,7 +330,7 @@ mod tests {
         let client = make_client();
         let mut request = client.get("/");
 
-        let origin = Header::new(hyper::header::ORIGIN.as_str(), "https://www.example.com");
+        let origin = Header::new(ORIGIN.as_str(), "https://www.example.com");
         request.add_header(origin);
 
         let outcome = Origin::from_request_sync(request.inner());
@@ -364,7 +366,7 @@ mod tests {
         let client = make_client();
         let mut request = client.get("/");
         let method = Header::new(
-            hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+            ACCESS_CONTROL_REQUEST_METHOD.as_str(),
             hyper::Method::GET.as_str(),
         );
         request.add_header(method);
@@ -390,7 +392,7 @@ mod tests {
         let client = make_client();
         let mut request = client.get("/");
         let headers = Header::new(
-            hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
+            ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
             "accept-language, date",
         );
         request.add_header(headers);

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -205,8 +205,8 @@ impl<'a, 'r> FromRequest<'a, 'r> for AccessControlRequestHeaders {
 mod tests {
     use std::str::FromStr;
 
-    use hyper;
     use rocket;
+    use rocket::http::hyper;
     use rocket::local::Client;
 
     use super::*;
@@ -313,7 +313,7 @@ mod tests {
     fn request_method_parsing() {
         let client = make_client();
         let mut request = client.get("/");
-        let method = hyper::header::AccessControlRequestMethod(hyper::method::Method::Get);
+        let method = hyper::header::AccessControlRequestMethod(hyper::Method::Get);
         request.add_header(method);
         let outcome: request::Outcome<AccessControlRequestMethod, crate::Error> =
             FromRequest::from_request(request.inner());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,7 +261,7 @@ See the [example](https://github.com/lawliet89/rocket_cors/blob/master/examples/
     missing_debug_implementations,
     unknown_lints,
     unsafe_code,
-    intra_doc_link_resolution_failure
+    broken_intra_doc_links
 )]
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 
@@ -2037,11 +2037,15 @@ mod tests {
     use rocket::http::hyper;
     use rocket::http::Header;
     use rocket::local::blocking::Client;
-    #[cfg(feature = "serialization")]
-    use serde_json;
 
     use super::*;
     use crate::http::Method;
+
+    static ORIGIN: hyper::HeaderName = hyper::header::ORIGIN;
+    static ACCESS_CONTROL_REQUEST_METHOD: hyper::HeaderName =
+        hyper::header::ACCESS_CONTROL_REQUEST_METHOD;
+    static ACCESS_CONTROL_REQUEST_HEADERS: hyper::HeaderName =
+        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS;
 
     fn to_parsed_origin<S: AsRef<str>>(origin: S) -> Result<Origin, Error> {
         Origin::from_str(origin.as_ref())
@@ -2600,15 +2604,12 @@ mod tests {
         let cors = make_cors_options().to_cors().expect("To not fail");
         let client = make_client();
 
-        let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+        let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
         let method_header = Header::new(
-            hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+            ACCESS_CONTROL_REQUEST_METHOD.as_str(),
             hyper::Method::GET.as_str(),
         );
-        let request_headers = Header::new(
-            hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-            "Authorization",
-        );
+        let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
 
         let request = client
             .options("/")
@@ -2634,15 +2635,12 @@ mod tests {
         let cors = options.to_cors().expect("To not fail");
         let client = make_client();
 
-        let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.example.com");
+        let origin_header = Header::new(ORIGIN.as_str(), "https://www.example.com");
         let method_header = Header::new(
-            hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+            ACCESS_CONTROL_REQUEST_METHOD.as_str(),
             hyper::Method::GET.as_str(),
         );
-        let request_headers = Header::new(
-            hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-            "Authorization",
-        );
+        let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
 
         let request = client
             .options("/")
@@ -2665,15 +2663,12 @@ mod tests {
         let cors = make_cors_options().to_cors().expect("To not fail");
         let client = make_client();
 
-        let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.example.com");
+        let origin_header = Header::new(ORIGIN.as_str(), "https://www.example.com");
         let method_header = Header::new(
-            hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+            ACCESS_CONTROL_REQUEST_METHOD.as_str(),
             hyper::Method::GET.as_str(),
         );
-        let request_headers = Header::new(
-            hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-            "Authorization",
-        );
+        let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
 
         let request = client
             .options("/")
@@ -2690,11 +2685,8 @@ mod tests {
         let cors = make_cors_options().to_cors().expect("To not fail");
         let client = make_client();
 
-        let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
-        let request_headers = Header::new(
-            hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-            "Authorization",
-        );
+        let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
+        let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
 
         let request = client
             .options("/")
@@ -2710,15 +2702,12 @@ mod tests {
         let cors = make_cors_options().to_cors().expect("To not fail");
         let client = make_client();
 
-        let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+        let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
         let method_header = Header::new(
-            hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+            ACCESS_CONTROL_REQUEST_METHOD.as_str(),
             hyper::Method::POST.as_str(),
         );
-        let request_headers = Header::new(
-            hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-            "Authorization",
-        );
+        let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
 
         let request = client
             .options("/")
@@ -2735,13 +2724,13 @@ mod tests {
         let cors = make_cors_options().to_cors().expect("To not fail");
         let client = make_client();
 
-        let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+        let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
         let method_header = Header::new(
-            hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+            ACCESS_CONTROL_REQUEST_METHOD.as_str(),
             hyper::Method::GET.as_str(),
         );
         let request_headers = Header::new(
-            hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
+            ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
             "Authorization, X-NOT-ALLOWED",
         );
 
@@ -2759,7 +2748,7 @@ mod tests {
         let cors = make_cors_options().to_cors().expect("To not fail");
         let client = make_client();
 
-        let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+        let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
         let request = client.get("/").header(origin_header);
 
         let result = validate(&cors, request.inner()).expect("to not fail");
@@ -2777,7 +2766,7 @@ mod tests {
         let cors = options.to_cors().expect("To not fail");
         let client = make_client();
 
-        let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.example.com");
+        let origin_header = Header::new(ORIGIN.as_str(), "https://www.example.com");
         let request = client.get("/").header(origin_header);
 
         let result = validate(&cors, request.inner()).expect("to not fail");
@@ -2794,7 +2783,7 @@ mod tests {
         let cors = make_cors_options().to_cors().expect("To not fail");
         let client = make_client();
 
-        let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.example.com");
+        let origin_header = Header::new(ORIGIN.as_str(), "https://www.example.com");
         let request = client.get("/").header(origin_header);
 
         let _ = validate(&cors, request.inner()).unwrap();
@@ -2817,15 +2806,12 @@ mod tests {
         let cors = options.to_cors().expect("To not fail");
         let client = make_client();
 
-        let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+        let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
         let method_header = Header::new(
-            hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+            ACCESS_CONTROL_REQUEST_METHOD.as_str(),
             hyper::Method::GET.as_str(),
         );
-        let request_headers = Header::new(
-            hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-            "Authorization",
-        );
+        let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
 
         let request = client
             .options("/")
@@ -2856,15 +2842,12 @@ mod tests {
 
         let client = make_client();
 
-        let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+        let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
         let method_header = Header::new(
-            hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+            ACCESS_CONTROL_REQUEST_METHOD.as_str(),
             hyper::Method::GET.as_str(),
         );
-        let request_headers = Header::new(
-            hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-            "Authorization",
-        );
+        let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
 
         let request = client
             .options("/")
@@ -2895,15 +2878,12 @@ mod tests {
 
         let client = make_client();
 
-        let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+        let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
         let method_header = Header::new(
-            hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+            ACCESS_CONTROL_REQUEST_METHOD.as_str(),
             hyper::Method::GET.as_str(),
         );
-        let request_headers = Header::new(
-            hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-            "Authorization",
-        );
+        let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
 
         let request = client
             .options("/")
@@ -2929,7 +2909,7 @@ mod tests {
         let cors = options.to_cors().expect("To not fail");
         let client = make_client();
 
-        let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+        let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
         let request = client.get("/").header(origin_header);
 
         let response = validate_and_build(&cors, request.inner()).expect("to not fail");
@@ -2951,7 +2931,7 @@ mod tests {
 
         let client = make_client();
 
-        let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+        let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
         let request = client.get("/").header(origin_header);
 
         let response = validate_and_build(&cors, request.inner()).expect("to not fail");
@@ -2973,7 +2953,7 @@ mod tests {
 
         let client = make_client();
 
-        let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+        let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
         let request = client.get("/").header(origin_header);
 
         let response = validate_and_build(&cors, request.inner()).expect("to not fail");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2018,6 +2018,7 @@ fn catch_all_options_route_handler<'r>(
 mod tests {
     use std::str::FromStr;
 
+    use rocket::http::hyper;
     use rocket::http::Header;
     use rocket::local::Client;
     #[cfg(feature = "serialization")]
@@ -2575,7 +2576,7 @@ mod tests {
         let origin_header =
             Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
         let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-            hyper::method::Method::Get,
+            hyper::Method::Get,
         ));
         let request_headers =
             hyper::header::AccessControlRequestHeaders(vec![
@@ -2610,7 +2611,7 @@ mod tests {
         let origin_header =
             Header::from(hyper::header::Origin::from_str("https://www.example.com").unwrap());
         let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-            hyper::method::Method::Get,
+            hyper::Method::Get,
         ));
         let request_headers =
             hyper::header::AccessControlRequestHeaders(vec![
@@ -2642,7 +2643,7 @@ mod tests {
         let origin_header =
             Header::from(hyper::header::Origin::from_str("https://www.example.com").unwrap());
         let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-            hyper::method::Method::Get,
+            hyper::Method::Get,
         ));
         let request_headers =
             hyper::header::AccessControlRequestHeaders(vec![
@@ -2690,7 +2691,7 @@ mod tests {
         let origin_header =
             Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
         let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-            hyper::method::Method::Post,
+            hyper::Method::Post,
         ));
         let request_headers =
             hyper::header::AccessControlRequestHeaders(vec![
@@ -2716,7 +2717,7 @@ mod tests {
         let origin_header =
             Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
         let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-            hyper::method::Method::Get,
+            hyper::Method::Get,
         ));
         let request_headers = hyper::header::AccessControlRequestHeaders(vec![
             FromStr::from_str("Authorization").unwrap(),
@@ -2802,7 +2803,7 @@ mod tests {
         let origin_header =
             Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
         let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-            hyper::method::Method::Get,
+            hyper::Method::Get,
         ));
         let request_headers =
             hyper::header::AccessControlRequestHeaders(vec![
@@ -2842,7 +2843,7 @@ mod tests {
         let origin_header =
             Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
         let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-            hyper::method::Method::Get,
+            hyper::Method::Get,
         ));
         let request_headers =
             hyper::header::AccessControlRequestHeaders(vec![
@@ -2882,7 +2883,7 @@ mod tests {
         let origin_header =
             Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
         let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-            hyper::method::Method::Get,
+            hyper::Method::Get,
         ));
         let request_headers =
             hyper::header::AccessControlRequestHeaders(vec![

--- a/tests/fairing.rs
+++ b/tests/fairing.rs
@@ -7,13 +7,19 @@ use rocket::local::blocking::Client;
 use rocket::{get, routes};
 use rocket_cors::*;
 
+static ORIGIN: hyper::HeaderName = hyper::header::ORIGIN;
+static ACCESS_CONTROL_REQUEST_METHOD: hyper::HeaderName =
+    hyper::header::ACCESS_CONTROL_REQUEST_METHOD;
+static ACCESS_CONTROL_REQUEST_HEADERS: hyper::HeaderName =
+    hyper::header::ACCESS_CONTROL_REQUEST_HEADERS;
+
 #[get("/")]
 fn cors<'a>() -> &'a str {
     "Hello CORS"
 }
 
 #[get("/panic")]
-fn panicking_route() {
+fn panicking_route<'a>() -> &'a str {
     panic!("This route will panic");
 }
 
@@ -42,15 +48,12 @@ fn smoke_test() {
     let client = Client::new(rocket()).unwrap();
 
     // `Options` pre-flight checks
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/")
         .header(origin_header)
@@ -61,7 +64,7 @@ fn smoke_test() {
     assert!(response.status().class().is_success());
 
     // "Actual" request
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let authorization = Header::new("Authorization", "let me in");
     let req = client.get("/").header(origin_header).header(authorization);
 
@@ -80,15 +83,12 @@ fn smoke_test() {
 fn cors_options_check() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/")
         .header(origin_header)
@@ -109,7 +109,7 @@ fn cors_options_check() {
 fn cors_get_check() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let authorization = Header::new("Authorization", "let me in");
     let req = client.get("/").header(origin_header).header(authorization);
 
@@ -142,15 +142,12 @@ fn cors_get_no_origin() {
 fn cors_options_bad_origin() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.bad-origin.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.bad-origin.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/")
         .header(origin_header)
@@ -167,13 +164,10 @@ fn cors_options_missing_origin() {
     let client = Client::new(rocket()).unwrap();
 
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/")
         .header(method_header)
@@ -192,15 +186,12 @@ fn cors_options_missing_origin() {
 fn cors_options_bad_request_method() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::POST.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/")
         .header(origin_header)
@@ -219,15 +210,12 @@ fn cors_options_bad_request_method() {
 fn cors_options_bad_request_header() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Foobar",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Foobar");
     let req = client
         .options("/")
         .header(origin_header)
@@ -246,7 +234,7 @@ fn cors_options_bad_request_header() {
 fn cors_get_bad_origin() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.bad-origin.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.bad-origin.com");
     let authorization = Header::new("Authorization", "let me in");
     let req = client.get("/").header(origin_header).header(authorization);
 
@@ -265,15 +253,12 @@ fn cors_get_bad_origin() {
 fn routes_failing_checks_are_not_executed() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.bad-origin.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.bad-origin.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/panic")
         .header(origin_header)

--- a/tests/fairing.rs
+++ b/tests/fairing.rs
@@ -1,5 +1,4 @@
 //! This crate tests using `rocket_cors` using Fairings
-#![feature(proc_macro_hygiene, decl_macro)]
 use rocket::http::hyper;
 use rocket::http::Method;
 use rocket::http::{Header, Status};

--- a/tests/fairing.rs
+++ b/tests/fairing.rs
@@ -1,12 +1,9 @@
 //! This crate tests using `rocket_cors` using Fairings
 #![feature(proc_macro_hygiene, decl_macro)]
-use std::str::FromStr;
-
 use rocket::http::hyper;
 use rocket::http::Method;
 use rocket::http::{Header, Status};
-use rocket::local::Client;
-use rocket::response::Body;
+use rocket::local::blocking::Client;
 use rocket::{get, routes};
 use rocket_cors::*;
 
@@ -45,16 +42,15 @@ fn smoke_test() {
     let client = Client::new(rocket()).unwrap();
 
     // `Options` pre-flight checks
-    let origin_header =
-        Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
-    let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::Method::Get,
-    ));
-    let request_headers =
-        hyper::header::AccessControlRequestHeaders(vec![
-            FromStr::from_str("Authorization").unwrap()
-        ]);
-    let request_headers = Header::from(request_headers);
+    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let method_header = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        hyper::Method::GET.as_str(),
+    );
+    let request_headers = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
+        "Authorization",
+    );
     let req = client
         .options("/")
         .header(origin_header)
@@ -65,37 +61,34 @@ fn smoke_test() {
     assert!(response.status().class().is_success());
 
     // "Actual" request
-    let origin_header =
-        Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
+    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
     let authorization = Header::new("Authorization", "let me in");
     let req = client.get("/").header(origin_header).header(authorization);
 
-    let mut response = req.dispatch();
+    let response = req.dispatch();
     assert!(response.status().class().is_success());
-    let body_str = response.body().and_then(Body::into_string);
-    assert_eq!(body_str, Some("Hello CORS".to_string()));
-
     let origin_header = response
         .headers()
         .get_one("Access-Control-Allow-Origin")
         .expect("to exist");
     assert_eq!("https://www.acme.com", origin_header);
+    let body_str = response.into_string();
+    assert_eq!(body_str, Some("Hello CORS".to_string()));
 }
 
 #[test]
 fn cors_options_check() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header =
-        Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
-    let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::Method::Get,
-    ));
-    let request_headers =
-        hyper::header::AccessControlRequestHeaders(vec![
-            FromStr::from_str("Authorization").unwrap()
-        ]);
-    let request_headers = Header::from(request_headers);
+    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let method_header = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        hyper::Method::GET.as_str(),
+    );
+    let request_headers = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
+        "Authorization",
+    );
     let req = client
         .options("/")
         .header(origin_header)
@@ -116,21 +109,19 @@ fn cors_options_check() {
 fn cors_get_check() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header =
-        Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
+    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
     let authorization = Header::new("Authorization", "let me in");
     let req = client.get("/").header(origin_header).header(authorization);
 
-    let mut response = req.dispatch();
+    let response = req.dispatch();
     assert!(response.status().class().is_success());
-    let body_str = response.body().and_then(Body::into_string);
-    assert_eq!(body_str, Some("Hello CORS".to_string()));
-
     let origin_header = response
         .headers()
         .get_one("Access-Control-Allow-Origin")
         .expect("to exist");
     assert_eq!("https://www.acme.com", origin_header);
+    let body_str = response.into_string();
+    assert_eq!(body_str, Some("Hello CORS".to_string()));
 }
 
 /// This test is to check that non CORS compliant requests to GET should still work. (i.e. curl)
@@ -141,9 +132,9 @@ fn cors_get_no_origin() {
     let authorization = Header::new("Authorization", "let me in");
     let req = client.get("/").header(authorization);
 
-    let mut response = req.dispatch();
+    let response = req.dispatch();
     assert!(response.status().class().is_success());
-    let body_str = response.body().and_then(Body::into_string);
+    let body_str = response.into_string();
     assert_eq!(body_str, Some("Hello CORS".to_string()));
 }
 
@@ -151,16 +142,15 @@ fn cors_get_no_origin() {
 fn cors_options_bad_origin() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header =
-        Header::from(hyper::header::Origin::from_str("https://www.bad-origin.com").unwrap());
-    let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::Method::Get,
-    ));
-    let request_headers =
-        hyper::header::AccessControlRequestHeaders(vec![
-            FromStr::from_str("Authorization").unwrap()
-        ]);
-    let request_headers = Header::from(request_headers);
+    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.bad-origin.com");
+    let method_header = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        hyper::Method::GET.as_str(),
+    );
+    let request_headers = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
+        "Authorization",
+    );
     let req = client
         .options("/")
         .header(origin_header)
@@ -176,14 +166,14 @@ fn cors_options_bad_origin() {
 fn cors_options_missing_origin() {
     let client = Client::new(rocket()).unwrap();
 
-    let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::Method::Get,
-    ));
-    let request_headers =
-        hyper::header::AccessControlRequestHeaders(vec![
-            FromStr::from_str("Authorization").unwrap()
-        ]);
-    let request_headers = Header::from(request_headers);
+    let method_header = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        hyper::Method::GET.as_str(),
+    );
+    let request_headers = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
+        "Authorization",
+    );
     let req = client
         .options("/")
         .header(method_header)
@@ -202,16 +192,15 @@ fn cors_options_missing_origin() {
 fn cors_options_bad_request_method() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header =
-        Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
-    let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::Method::Post,
-    ));
-    let request_headers =
-        hyper::header::AccessControlRequestHeaders(vec![
-            FromStr::from_str("Authorization").unwrap()
-        ]);
-    let request_headers = Header::from(request_headers);
+    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let method_header = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        hyper::Method::POST.as_str(),
+    );
+    let request_headers = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
+        "Authorization",
+    );
     let req = client
         .options("/")
         .header(origin_header)
@@ -230,14 +219,15 @@ fn cors_options_bad_request_method() {
 fn cors_options_bad_request_header() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header =
-        Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
-    let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::Method::Get,
-    ));
-    let request_headers =
-        hyper::header::AccessControlRequestHeaders(vec![FromStr::from_str("Foobar").unwrap()]);
-    let request_headers = Header::from(request_headers);
+    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let method_header = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        hyper::Method::GET.as_str(),
+    );
+    let request_headers = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
+        "Foobar",
+    );
     let req = client
         .options("/")
         .header(origin_header)
@@ -256,8 +246,7 @@ fn cors_options_bad_request_header() {
 fn cors_get_bad_origin() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header =
-        Header::from(hyper::header::Origin::from_str("https://www.bad-origin.com").unwrap());
+    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.bad-origin.com");
     let authorization = Header::new("Authorization", "let me in");
     let req = client.get("/").header(origin_header).header(authorization);
 
@@ -276,16 +265,15 @@ fn cors_get_bad_origin() {
 fn routes_failing_checks_are_not_executed() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header =
-        Header::from(hyper::header::Origin::from_str("https://www.bad-origin.com").unwrap());
-    let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::Method::Get,
-    ));
-    let request_headers =
-        hyper::header::AccessControlRequestHeaders(vec![
-            FromStr::from_str("Authorization").unwrap()
-        ]);
-    let request_headers = Header::from(request_headers);
+    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.bad-origin.com");
+    let method_header = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        hyper::Method::GET.as_str(),
+    );
+    let request_headers = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
+        "Authorization",
+    );
     let req = client
         .options("/panic")
         .header(origin_header)

--- a/tests/fairing.rs
+++ b/tests/fairing.rs
@@ -1,9 +1,8 @@
 //! This crate tests using `rocket_cors` using Fairings
 #![feature(proc_macro_hygiene, decl_macro)]
-use hyper;
-
 use std::str::FromStr;
 
+use rocket::http::hyper;
 use rocket::http::Method;
 use rocket::http::{Header, Status};
 use rocket::local::Client;
@@ -49,7 +48,7 @@ fn smoke_test() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![
@@ -90,7 +89,7 @@ fn cors_options_check() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![
@@ -155,7 +154,7 @@ fn cors_options_bad_origin() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.bad-origin.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![
@@ -178,7 +177,7 @@ fn cors_options_missing_origin() {
     let client = Client::new(rocket()).unwrap();
 
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![
@@ -206,7 +205,7 @@ fn cors_options_bad_request_method() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Post,
+        hyper::Method::Post,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![
@@ -234,7 +233,7 @@ fn cors_options_bad_request_header() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![FromStr::from_str("Foobar").unwrap()]);
@@ -280,7 +279,7 @@ fn routes_failing_checks_are_not_executed() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.bad-origin.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![

--- a/tests/guard.rs
+++ b/tests/guard.rs
@@ -9,13 +9,19 @@ use rocket::local::blocking::Client;
 use rocket::{get, options, routes};
 use rocket::{Response, State};
 
+static ORIGIN: hyper::HeaderName = hyper::header::ORIGIN;
+static ACCESS_CONTROL_REQUEST_METHOD: hyper::HeaderName =
+    hyper::header::ACCESS_CONTROL_REQUEST_METHOD;
+static ACCESS_CONTROL_REQUEST_HEADERS: hyper::HeaderName =
+    hyper::header::ACCESS_CONTROL_REQUEST_HEADERS;
+
 #[get("/")]
 fn cors(cors: cors::Guard<'_>) -> cors::Responder<'_, '_, &str> {
     cors.responder("Hello CORS")
 }
 
 #[get("/panic")]
-fn panicking_route(_cors: cors::Guard<'_>) {
+fn panicking_route(_cors: cors::Guard<'_>) -> cors::Responder<'_, '_, &str> {
     panic!("This route will panic");
 }
 
@@ -92,15 +98,12 @@ fn smoke_test() {
     let client = Client::new(rocket).unwrap();
 
     // `Options` pre-flight checks
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/")
         .header(origin_header)
@@ -111,7 +114,7 @@ fn smoke_test() {
     assert!(response.status().class().is_success());
 
     // "Actual" request
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let authorization = Header::new("Authorization", "let me in");
     let req = client.get("/").header(origin_header).header(authorization);
 
@@ -132,15 +135,12 @@ fn cors_options_catch_all_check() {
     let rocket = make_rocket();
     let client = Client::new(rocket).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/")
         .header(origin_header)
@@ -163,15 +163,12 @@ fn cors_options_catch_all_check_other_routes() {
     let rocket = make_rocket();
     let client = Client::new(rocket).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/response/unit")
         .header(origin_header)
@@ -193,7 +190,7 @@ fn cors_get_check() {
     let rocket = make_rocket();
     let client = Client::new(rocket).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let authorization = Header::new("Authorization", "let me in");
     let req = client.get("/").header(origin_header).header(authorization);
 
@@ -232,15 +229,12 @@ fn cors_options_bad_origin() {
     let rocket = make_rocket();
     let client = Client::new(rocket).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.bad-origin.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.bad-origin.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/")
         .header(origin_header)
@@ -261,13 +255,10 @@ fn cors_options_missing_origin() {
     let client = Client::new(rocket).unwrap();
 
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/")
         .header(method_header)
@@ -286,15 +277,12 @@ fn cors_options_bad_request_method() {
     let rocket = make_rocket();
     let client = Client::new(rocket).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::POST.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/")
         .header(origin_header)
@@ -314,15 +302,12 @@ fn cors_options_bad_request_header() {
     let rocket = make_rocket();
     let client = Client::new(rocket).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Foobar",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Foobar");
     let req = client
         .options("/")
         .header(origin_header)
@@ -342,7 +327,7 @@ fn cors_get_bad_origin() {
     let rocket = make_rocket();
     let client = Client::new(rocket).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.bad-origin.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.bad-origin.com");
     let authorization = Header::new("Authorization", "let me in");
     let req = client.get("/").header(origin_header).header(authorization);
 
@@ -362,7 +347,7 @@ fn routes_failing_checks_are_not_executed() {
     let rocket = make_rocket();
     let client = Client::new(rocket).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.bad-origin.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.bad-origin.com");
     let authorization = Header::new("Authorization", "let me in");
     let req = client.get("/").header(origin_header).header(authorization);
 
@@ -381,15 +366,12 @@ fn overridden_options_routes_are_used() {
     let rocket = make_rocket();
     let client = Client::new(rocket).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/manual")
         .header(origin_header)

--- a/tests/guard.rs
+++ b/tests/guard.rs
@@ -1,5 +1,4 @@
 //! This crate tests using `rocket_cors` using the per-route handling with request guard
-#![feature(proc_macro_hygiene, decl_macro)]
 use rocket_cors as cors;
 
 use rocket::http::hyper;

--- a/tests/guard.rs
+++ b/tests/guard.rs
@@ -1,10 +1,10 @@
 //! This crate tests using `rocket_cors` using the per-route handling with request guard
 #![feature(proc_macro_hygiene, decl_macro)]
-use hyper;
 use rocket_cors as cors;
 
 use std::str::FromStr;
 
+use rocket::http::hyper;
 use rocket::http::Method;
 use rocket::http::{Header, Status};
 use rocket::local::Client;
@@ -95,7 +95,7 @@ fn smoke_test() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![
@@ -138,7 +138,7 @@ fn cors_options_catch_all_check() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![
@@ -170,7 +170,7 @@ fn cors_options_catch_all_check_other_routes() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![
@@ -242,7 +242,7 @@ fn cors_options_bad_origin() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.bad-origin.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![
@@ -269,7 +269,7 @@ fn cors_options_missing_origin() {
     let client = Client::new(rocket).unwrap();
 
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![
@@ -297,7 +297,7 @@ fn cors_options_bad_request_method() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Post,
+        hyper::Method::Post,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![
@@ -326,7 +326,7 @@ fn cors_options_bad_request_header() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![FromStr::from_str("Foobar").unwrap()]);
@@ -394,7 +394,7 @@ fn overridden_options_routes_are_used() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![

--- a/tests/headers.rs
+++ b/tests/headers.rs
@@ -8,6 +8,12 @@ use rocket::local::blocking::Client;
 use rocket::{get, routes};
 use rocket_cors::headers::*;
 
+static ORIGIN: hyper::HeaderName = hyper::header::ORIGIN;
+static ACCESS_CONTROL_REQUEST_METHOD: hyper::HeaderName =
+    hyper::header::ACCESS_CONTROL_REQUEST_METHOD;
+static ACCESS_CONTROL_REQUEST_HEADERS: hyper::HeaderName =
+    hyper::header::ACCESS_CONTROL_REQUEST_HEADERS;
+
 #[get("/request_headers")]
 fn request_headers(
     origin: Origin,
@@ -30,13 +36,13 @@ fn request_headers_round_trip_smoke_test() {
     let rocket = rocket::ignite().mount("/", routes![request_headers]);
     let client = Client::new(rocket).expect("A valid Rocket client");
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://foo.bar.xyz");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://foo.bar.xyz");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
     let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
+        ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
         "accept-language, X-Ping",
     );
     let req = client

--- a/tests/headers.rs
+++ b/tests/headers.rs
@@ -1,5 +1,4 @@
 //! This crate tests that all the request headers are parsed correctly in the round trip
-#![feature(proc_macro_hygiene, decl_macro)]
 use std::ops::Deref;
 
 use rocket::http::hyper;

--- a/tests/headers.rs
+++ b/tests/headers.rs
@@ -1,10 +1,9 @@
 //! This crate tests that all the request headers are parsed correctly in the round trip
 #![feature(proc_macro_hygiene, decl_macro)]
-use hyper;
-
 use std::ops::Deref;
 use std::str::FromStr;
 
+use rocket::http::hyper;
 use rocket::http::Header;
 use rocket::local::Client;
 use rocket::response::Body;
@@ -36,7 +35,7 @@ fn request_headers_round_trip_smoke_test() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://foo.bar.xyz").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers = hyper::header::AccessControlRequestHeaders(vec![
         FromStr::from_str("accept-language").unwrap(),

--- a/tests/manual.rs
+++ b/tests/manual.rs
@@ -9,6 +9,12 @@ use rocket::State;
 use rocket::{get, options, routes};
 use rocket_cors::*;
 
+static ORIGIN: hyper::HeaderName = hyper::header::ORIGIN;
+static ACCESS_CONTROL_REQUEST_METHOD: hyper::HeaderName =
+    hyper::header::ACCESS_CONTROL_REQUEST_METHOD;
+static ACCESS_CONTROL_REQUEST_HEADERS: hyper::HeaderName =
+    hyper::header::ACCESS_CONTROL_REQUEST_HEADERS;
+
 /// Using a borrowed `Cors`
 #[get("/")]
 fn cors(options: State<'_, Cors>) -> impl Responder<'_, '_> {
@@ -44,6 +50,7 @@ fn owned<'r, 'o: 'r>() -> impl Responder<'r, 'o> {
 
 /// `Responder` with String
 #[get("/")]
+#[allow(dead_code)]
 fn responder_string(options: State<'_, Cors>) -> impl Responder<'_, '_> {
     options
         .inner()
@@ -53,6 +60,7 @@ fn responder_string(options: State<'_, Cors>) -> impl Responder<'_, '_> {
 struct TestState;
 /// Borrow something else from Rocket with lifetime `'r`
 #[get("/")]
+#[allow(dead_code)]
 fn borrow<'r, 'o: 'r>(
     options: State<'r, Cors>,
     test_state: State<'r, TestState>,
@@ -101,15 +109,12 @@ fn smoke_test() {
     let client = Client::new(rocket()).unwrap();
 
     // `Options` pre-flight checks
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/")
         .header(origin_header)
@@ -120,7 +125,7 @@ fn smoke_test() {
     assert!(response.status().class().is_success());
 
     // "Actual" request
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let authorization = Header::new("Authorization", "let me in");
     let req = client.get("/").header(origin_header).header(authorization);
 
@@ -139,15 +144,12 @@ fn smoke_test() {
 fn cors_options_borrowed_check() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/")
         .header(origin_header)
@@ -168,7 +170,7 @@ fn cors_options_borrowed_check() {
 fn cors_get_borrowed_check() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let authorization = Header::new("Authorization", "let me in");
     let req = client.get("/").header(origin_header).header(authorization);
 
@@ -201,15 +203,12 @@ fn cors_get_no_origin() {
 fn cors_options_bad_origin() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.bad-origin.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.bad-origin.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/")
         .header(origin_header)
@@ -225,13 +224,10 @@ fn cors_options_missing_origin() {
     let client = Client::new(rocket()).unwrap();
 
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/")
         .header(method_header)
@@ -249,15 +245,12 @@ fn cors_options_missing_origin() {
 fn cors_options_bad_request_method() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::POST.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/")
         .header(origin_header)
@@ -276,15 +269,12 @@ fn cors_options_bad_request_method() {
 fn cors_options_bad_request_header() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Foobar",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Foobar");
     let req = client
         .options("/")
         .header(origin_header)
@@ -303,7 +293,7 @@ fn cors_options_bad_request_header() {
 fn cors_get_bad_origin() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.bad-origin.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.bad-origin.com");
     let authorization = Header::new("Authorization", "let me in");
     let req = client.get("/").header(origin_header).header(authorization);
 
@@ -322,15 +312,12 @@ fn cors_get_bad_origin() {
 fn routes_failing_checks_are_not_executed() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.bad-origin.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.bad-origin.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/panic")
         .header(origin_header)
@@ -351,15 +338,12 @@ fn cors_options_owned_check() {
     let rocket = rocket();
     let client = Client::new(rocket).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.example.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.example.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/owned")
         .header(origin_header)
@@ -383,7 +367,7 @@ fn cors_options_owned_check() {
 fn cors_get_owned_check() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.example.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.example.com");
     let authorization = Header::new("Authorization", "let me in");
     let req = client
         .get("/owned")

--- a/tests/manual.rs
+++ b/tests/manual.rs
@@ -1,5 +1,4 @@
 //! This crate tests using `rocket_cors` using manual mode
-#![feature(proc_macro_hygiene, decl_macro)]
 use rocket::http::hyper;
 use rocket::http::Method;
 use rocket::http::{Header, Status};

--- a/tests/manual.rs
+++ b/tests/manual.rs
@@ -1,12 +1,9 @@
 //! This crate tests using `rocket_cors` using manual mode
 #![feature(proc_macro_hygiene, decl_macro)]
-use std::str::FromStr;
-
 use rocket::http::hyper;
 use rocket::http::Method;
 use rocket::http::{Header, Status};
-use rocket::local::Client;
-use rocket::response::Body;
+use rocket::local::blocking::Client;
 use rocket::response::Responder;
 use rocket::State;
 use rocket::{get, options, routes};
@@ -14,14 +11,14 @@ use rocket_cors::*;
 
 /// Using a borrowed `Cors`
 #[get("/")]
-fn cors(options: State<'_, Cors>) -> impl Responder<'_> {
+fn cors(options: State<'_, Cors>) -> impl Responder<'_, '_> {
     options
         .inner()
         .respond_borrowed(|guard| guard.responder("Hello CORS"))
 }
 
 #[get("/panic")]
-fn panicking_route(options: State<'_, Cors>) -> impl Responder<'_> {
+fn panicking_route(options: State<'_, Cors>) -> impl Responder<'_, '_> {
     options.inner().respond_borrowed(|_| {
         panic!("This route will panic");
     })
@@ -29,7 +26,7 @@ fn panicking_route(options: State<'_, Cors>) -> impl Responder<'_> {
 
 /// Respond with an owned option instead
 #[options("/owned")]
-fn owned_options<'r>() -> impl Responder<'r> {
+fn owned_options<'r, 'o: 'r>() -> impl Responder<'r, 'o> {
     let borrow = make_different_cors_options().to_cors()?;
 
     borrow.respond_owned(|guard| guard.responder("Manual CORS Preflight"))
@@ -37,7 +34,7 @@ fn owned_options<'r>() -> impl Responder<'r> {
 
 /// Respond with an owned option instead
 #[get("/owned")]
-fn owned<'r>() -> impl Responder<'r> {
+fn owned<'r, 'o: 'r>() -> impl Responder<'r, 'o> {
     let borrow = make_different_cors_options().to_cors()?;
 
     borrow.respond_owned(|guard| guard.responder("Hello CORS Owned"))
@@ -47,7 +44,7 @@ fn owned<'r>() -> impl Responder<'r> {
 
 /// `Responder` with String
 #[get("/")]
-fn responder_string(options: State<'_, Cors>) -> impl Responder<'_> {
+fn responder_string(options: State<'_, Cors>) -> impl Responder<'_, '_> {
     options
         .inner()
         .respond_borrowed(|guard| guard.responder("Hello CORS".to_string()))
@@ -56,7 +53,10 @@ fn responder_string(options: State<'_, Cors>) -> impl Responder<'_> {
 struct TestState;
 /// Borrow something else from Rocket with lifetime `'r`
 #[get("/")]
-fn borrow<'r>(options: State<'r, Cors>, test_state: State<'r, TestState>) -> impl Responder<'r> {
+fn borrow<'r, 'o: 'r>(
+    options: State<'r, Cors>,
+    test_state: State<'r, TestState>,
+) -> impl Responder<'r, 'o> {
     let borrow = test_state.inner();
     options.inner().respond_borrowed(move |guard| {
         let _ = borrow;
@@ -101,16 +101,15 @@ fn smoke_test() {
     let client = Client::new(rocket()).unwrap();
 
     // `Options` pre-flight checks
-    let origin_header =
-        Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
-    let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::Method::Get,
-    ));
-    let request_headers =
-        hyper::header::AccessControlRequestHeaders(vec![
-            FromStr::from_str("Authorization").unwrap()
-        ]);
-    let request_headers = Header::from(request_headers);
+    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let method_header = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        hyper::Method::GET.as_str(),
+    );
+    let request_headers = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
+        "Authorization",
+    );
     let req = client
         .options("/")
         .header(origin_header)
@@ -121,37 +120,34 @@ fn smoke_test() {
     assert!(response.status().class().is_success());
 
     // "Actual" request
-    let origin_header =
-        Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
+    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
     let authorization = Header::new("Authorization", "let me in");
     let req = client.get("/").header(origin_header).header(authorization);
 
-    let mut response = req.dispatch();
+    let response = req.dispatch();
     assert!(response.status().class().is_success());
-    let body_str = response.body().and_then(Body::into_string);
-    assert_eq!(body_str, Some("Hello CORS".to_string()));
-
     let origin_header = response
         .headers()
         .get_one("Access-Control-Allow-Origin")
         .expect("to exist");
     assert_eq!("https://www.acme.com", origin_header);
+    let body_str = response.into_string();
+    assert_eq!(body_str, Some("Hello CORS".to_string()));
 }
 
 #[test]
 fn cors_options_borrowed_check() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header =
-        Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
-    let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::Method::Get,
-    ));
-    let request_headers =
-        hyper::header::AccessControlRequestHeaders(vec![
-            FromStr::from_str("Authorization").unwrap()
-        ]);
-    let request_headers = Header::from(request_headers);
+    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let method_header = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        hyper::Method::GET.as_str(),
+    );
+    let request_headers = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
+        "Authorization",
+    );
     let req = client
         .options("/")
         .header(origin_header)
@@ -172,21 +168,19 @@ fn cors_options_borrowed_check() {
 fn cors_get_borrowed_check() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header =
-        Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
+    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
     let authorization = Header::new("Authorization", "let me in");
     let req = client.get("/").header(origin_header).header(authorization);
 
-    let mut response = req.dispatch();
+    let response = req.dispatch();
     assert!(response.status().class().is_success());
-    let body_str = response.body().and_then(Body::into_string);
-    assert_eq!(body_str, Some("Hello CORS".to_string()));
-
     let origin_header = response
         .headers()
         .get_one("Access-Control-Allow-Origin")
         .expect("to exist");
     assert_eq!("https://www.acme.com", origin_header);
+    let body_str = response.into_string();
+    assert_eq!(body_str, Some("Hello CORS".to_string()));
 }
 
 /// This test is to check that non CORS compliant requests to GET should still work. (i.e. curl)
@@ -197,9 +191,9 @@ fn cors_get_no_origin() {
     let authorization = Header::new("Authorization", "let me in");
     let req = client.get("/").header(authorization);
 
-    let mut response = req.dispatch();
+    let response = req.dispatch();
     assert!(response.status().class().is_success());
-    let body_str = response.body().and_then(Body::into_string);
+    let body_str = response.into_string();
     assert_eq!(body_str, Some("Hello CORS".to_string()));
 }
 
@@ -207,16 +201,15 @@ fn cors_get_no_origin() {
 fn cors_options_bad_origin() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header =
-        Header::from(hyper::header::Origin::from_str("https://www.bad-origin.com").unwrap());
-    let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::Method::Get,
-    ));
-    let request_headers =
-        hyper::header::AccessControlRequestHeaders(vec![
-            FromStr::from_str("Authorization").unwrap()
-        ]);
-    let request_headers = Header::from(request_headers);
+    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.bad-origin.com");
+    let method_header = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        hyper::Method::GET.as_str(),
+    );
+    let request_headers = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
+        "Authorization",
+    );
     let req = client
         .options("/")
         .header(origin_header)
@@ -231,14 +224,14 @@ fn cors_options_bad_origin() {
 fn cors_options_missing_origin() {
     let client = Client::new(rocket()).unwrap();
 
-    let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::Method::Get,
-    ));
-    let request_headers =
-        hyper::header::AccessControlRequestHeaders(vec![
-            FromStr::from_str("Authorization").unwrap()
-        ]);
-    let request_headers = Header::from(request_headers);
+    let method_header = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        hyper::Method::GET.as_str(),
+    );
+    let request_headers = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
+        "Authorization",
+    );
     let req = client
         .options("/")
         .header(method_header)
@@ -256,16 +249,15 @@ fn cors_options_missing_origin() {
 fn cors_options_bad_request_method() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header =
-        Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
-    let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::Method::Post,
-    ));
-    let request_headers =
-        hyper::header::AccessControlRequestHeaders(vec![
-            FromStr::from_str("Authorization").unwrap()
-        ]);
-    let request_headers = Header::from(request_headers);
+    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let method_header = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        hyper::Method::POST.as_str(),
+    );
+    let request_headers = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
+        "Authorization",
+    );
     let req = client
         .options("/")
         .header(origin_header)
@@ -284,14 +276,15 @@ fn cors_options_bad_request_method() {
 fn cors_options_bad_request_header() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header =
-        Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
-    let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::Method::Get,
-    ));
-    let request_headers =
-        hyper::header::AccessControlRequestHeaders(vec![FromStr::from_str("Foobar").unwrap()]);
-    let request_headers = Header::from(request_headers);
+    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let method_header = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        hyper::Method::GET.as_str(),
+    );
+    let request_headers = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
+        "Foobar",
+    );
     let req = client
         .options("/")
         .header(origin_header)
@@ -310,8 +303,7 @@ fn cors_options_bad_request_header() {
 fn cors_get_bad_origin() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header =
-        Header::from(hyper::header::Origin::from_str("https://www.bad-origin.com").unwrap());
+    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.bad-origin.com");
     let authorization = Header::new("Authorization", "let me in");
     let req = client.get("/").header(origin_header).header(authorization);
 
@@ -330,16 +322,15 @@ fn cors_get_bad_origin() {
 fn routes_failing_checks_are_not_executed() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header =
-        Header::from(hyper::header::Origin::from_str("https://www.bad-origin.com").unwrap());
-    let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::Method::Get,
-    ));
-    let request_headers =
-        hyper::header::AccessControlRequestHeaders(vec![
-            FromStr::from_str("Authorization").unwrap()
-        ]);
-    let request_headers = Header::from(request_headers);
+    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.bad-origin.com");
+    let method_header = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        hyper::Method::GET.as_str(),
+    );
+    let request_headers = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
+        "Authorization",
+    );
     let req = client
         .options("/panic")
         .header(origin_header)
@@ -360,32 +351,31 @@ fn cors_options_owned_check() {
     let rocket = rocket();
     let client = Client::new(rocket).unwrap();
 
-    let origin_header =
-        Header::from(hyper::header::Origin::from_str("https://www.example.com").unwrap());
-    let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::Method::Get,
-    ));
-    let request_headers =
-        hyper::header::AccessControlRequestHeaders(vec![
-            FromStr::from_str("Authorization").unwrap()
-        ]);
-    let request_headers = Header::from(request_headers);
+    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.example.com");
+    let method_header = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        hyper::Method::GET.as_str(),
+    );
+    let request_headers = Header::new(
+        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
+        "Authorization",
+    );
     let req = client
         .options("/owned")
         .header(origin_header)
         .header(method_header)
         .header(request_headers);
 
-    let mut response = req.dispatch();
-    let body_str = response.body().and_then(Body::into_string);
+    let response = req.dispatch();
     assert!(response.status().class().is_success());
-    assert_eq!(body_str, Some("Manual CORS Preflight".to_string()));
-
     let origin_header = response
         .headers()
         .get_one("Access-Control-Allow-Origin")
         .expect("to exist");
     assert_eq!("https://www.example.com", origin_header);
+
+    let body_str = response.into_string();
+    assert_eq!(body_str, Some("Manual CORS Preflight".to_string()));
 }
 
 /// Owned manual response works
@@ -393,22 +383,20 @@ fn cors_options_owned_check() {
 fn cors_get_owned_check() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header =
-        Header::from(hyper::header::Origin::from_str("https://www.example.com").unwrap());
+    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.example.com");
     let authorization = Header::new("Authorization", "let me in");
     let req = client
         .get("/owned")
         .header(origin_header)
         .header(authorization);
 
-    let mut response = req.dispatch();
+    let response = req.dispatch();
     assert!(response.status().class().is_success());
-    let body_str = response.body().and_then(Body::into_string);
-    assert_eq!(body_str, Some("Hello CORS Owned".to_string()));
-
     let origin_header = response
         .headers()
         .get_one("Access-Control-Allow-Origin")
         .expect("to exist");
     assert_eq!("https://www.example.com", origin_header);
+    let body_str = response.into_string();
+    assert_eq!(body_str, Some("Hello CORS Owned".to_string()));
 }

--- a/tests/manual.rs
+++ b/tests/manual.rs
@@ -1,9 +1,8 @@
 //! This crate tests using `rocket_cors` using manual mode
 #![feature(proc_macro_hygiene, decl_macro)]
-use hyper;
-
 use std::str::FromStr;
 
+use rocket::http::hyper;
 use rocket::http::Method;
 use rocket::http::{Header, Status};
 use rocket::local::Client;
@@ -105,7 +104,7 @@ fn smoke_test() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![
@@ -146,7 +145,7 @@ fn cors_options_borrowed_check() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![
@@ -211,7 +210,7 @@ fn cors_options_bad_origin() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.bad-origin.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![
@@ -233,7 +232,7 @@ fn cors_options_missing_origin() {
     let client = Client::new(rocket()).unwrap();
 
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![
@@ -260,7 +259,7 @@ fn cors_options_bad_request_method() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Post,
+        hyper::Method::Post,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![
@@ -288,7 +287,7 @@ fn cors_options_bad_request_header() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![FromStr::from_str("Foobar").unwrap()]);
@@ -334,7 +333,7 @@ fn routes_failing_checks_are_not_executed() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.bad-origin.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![
@@ -364,7 +363,7 @@ fn cors_options_owned_check() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.example.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![

--- a/tests/mix.rs
+++ b/tests/mix.rs
@@ -3,8 +3,6 @@
 //! In this example, you typically have an application wide `Cors` struct except for one specific
 //! `ping` route that you want to allow all Origins to access.
 #![feature(proc_macro_hygiene, decl_macro)]
-use rocket_cors;
-
 use rocket::http::hyper;
 use rocket::http::{Header, Method, Status};
 use rocket::local::blocking::Client;
@@ -12,6 +10,12 @@ use rocket::response::Responder;
 use rocket::{get, options, routes};
 
 use rocket_cors::{AllowedHeaders, AllowedOrigins, CorsOptions, Guard};
+
+static ORIGIN: hyper::HeaderName = hyper::header::ORIGIN;
+static ACCESS_CONTROL_REQUEST_METHOD: hyper::HeaderName =
+    hyper::header::ACCESS_CONTROL_REQUEST_METHOD;
+static ACCESS_CONTROL_REQUEST_HEADERS: hyper::HeaderName =
+    hyper::header::ACCESS_CONTROL_REQUEST_HEADERS;
 
 /// The "usual" app route
 #[get("/")]
@@ -70,15 +74,12 @@ fn smoke_test() {
     let client = Client::new(rocket()).unwrap();
 
     // `Options` pre-flight checks
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/")
         .header(origin_header)
@@ -89,7 +90,7 @@ fn smoke_test() {
     assert!(response.status().class().is_success());
 
     // "Actual" request
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let authorization = Header::new("Authorization", "let me in");
     let req = client.get("/").header(origin_header).header(authorization);
 
@@ -108,15 +109,12 @@ fn smoke_test() {
 fn cors_options_check() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/")
         .header(origin_header)
@@ -137,7 +135,7 @@ fn cors_options_check() {
 fn cors_get_check() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let authorization = Header::new("Authorization", "let me in");
     let req = client.get("/").header(origin_header).header(authorization);
 
@@ -170,15 +168,12 @@ fn cors_get_no_origin() {
 fn cors_options_bad_origin() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.bad-origin.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.bad-origin.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/")
         .header(origin_header)
@@ -194,13 +189,10 @@ fn cors_options_missing_origin() {
     let client = Client::new(rocket()).unwrap();
 
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/")
         .header(method_header)
@@ -218,15 +210,12 @@ fn cors_options_missing_origin() {
 fn cors_options_bad_request_method() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::POST.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Authorization",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Authorization");
     let req = client
         .options("/")
         .header(origin_header)
@@ -245,15 +234,12 @@ fn cors_options_bad_request_method() {
 fn cors_options_bad_request_header() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.acme.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.acme.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
-    let request_headers = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_HEADERS.as_str(),
-        "Foobar",
-    );
+    let request_headers = Header::new(ACCESS_CONTROL_REQUEST_HEADERS.as_str(), "Foobar");
     let req = client
         .options("/")
         .header(origin_header)
@@ -272,7 +258,7 @@ fn cors_options_bad_request_header() {
 fn cors_get_bad_origin() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.bad-origin.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.bad-origin.com");
     let authorization = Header::new("Authorization", "let me in");
     let req = client.get("/").header(origin_header).header(authorization);
 
@@ -289,9 +275,9 @@ fn cors_get_bad_origin() {
 fn cors_options_ping_check() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.example.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.example.com");
     let method_header = Header::new(
-        hyper::header::ACCESS_CONTROL_REQUEST_METHOD.as_str(),
+        ACCESS_CONTROL_REQUEST_METHOD.as_str(),
         hyper::Method::GET.as_str(),
     );
 
@@ -315,7 +301,7 @@ fn cors_options_ping_check() {
 fn cors_get_ping_check() {
     let client = Client::new(rocket()).unwrap();
 
-    let origin_header = Header::new(hyper::header::ORIGIN.as_str(), "https://www.example.com");
+    let origin_header = Header::new(ORIGIN.as_str(), "https://www.example.com");
 
     let req = client.get("/ping").header(origin_header);
 

--- a/tests/mix.rs
+++ b/tests/mix.rs
@@ -2,7 +2,6 @@
 //!
 //! In this example, you typically have an application wide `Cors` struct except for one specific
 //! `ping` route that you want to allow all Origins to access.
-#![feature(proc_macro_hygiene, decl_macro)]
 use rocket::http::hyper;
 use rocket::http::{Header, Method, Status};
 use rocket::local::blocking::Client;

--- a/tests/mix.rs
+++ b/tests/mix.rs
@@ -3,11 +3,11 @@
 //! In this example, you typically have an application wide `Cors` struct except for one specific
 //! `ping` route that you want to allow all Origins to access.
 #![feature(proc_macro_hygiene, decl_macro)]
-use hyper;
 use rocket_cors;
 
 use std::str::FromStr;
 
+use rocket::http::hyper;
 use rocket::http::{Header, Method, Status};
 use rocket::local::Client;
 use rocket::response::Body;
@@ -76,7 +76,7 @@ fn smoke_test() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![
@@ -117,7 +117,7 @@ fn cors_options_check() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![
@@ -182,7 +182,7 @@ fn cors_options_bad_origin() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.bad-origin.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![
@@ -204,7 +204,7 @@ fn cors_options_missing_origin() {
     let client = Client::new(rocket()).unwrap();
 
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![
@@ -231,7 +231,7 @@ fn cors_options_bad_request_method() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Post,
+        hyper::Method::Post,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![
@@ -259,7 +259,7 @@ fn cors_options_bad_request_header() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.acme.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
     let request_headers =
         hyper::header::AccessControlRequestHeaders(vec![FromStr::from_str("Foobar").unwrap()]);
@@ -303,7 +303,7 @@ fn cors_options_ping_check() {
     let origin_header =
         Header::from(hyper::header::Origin::from_str("https://www.example.com").unwrap());
     let method_header = Header::from(hyper::header::AccessControlRequestMethod(
-        hyper::method::Method::Get,
+        hyper::Method::Get,
     ));
 
     let req = client


### PR DESCRIPTION
* use hyper re-export from rocket_http
* switch rocket version to master branch
  (use release version once async is available)
* adapt code to incorporate changes from rocket and hyper

This fixes #79.

Update:
* make Clippy happy again
* make crate compile on Rust stable
* fix GitHub CI build