### PR TITLE
Update to latest master Rocket version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serialization = ["serde", "serde_derive", "unicase_serde"]
 
 [dependencies]
 regex = "1.1"
-rocket = { branch = "master", git = "https://github.com/SergioBenitez/Rocket.git", default-features = false }
+rocket = { rev="801e04bd5369eb39e126c75f6d11e1e9597304d8", git = "https://github.com/SergioBenitez/Rocket.git", default-features = false }
 log = "0.4"
 unicase = "2.0"
 url = "2.1.0"

--- a/examples/fairing.rs
+++ b/examples/fairing.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
     .to_cors()?;
 
-    rocket::ignite()
+    rocket::build()
         .mount("/", routes![cors])
         .attach(cors)
         .launch()

--- a/examples/guard.rs
+++ b/examples/guard.rs
@@ -47,7 +47,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
     .to_cors()?;
 
-    rocket::ignite()
+    rocket::build()
         .mount("/", routes![responder, response])
         // Mount the routes to catch all the OPTIONS pre-flight requests
         .mount("/", rocket_cors::catch_all_options_routes())

--- a/examples/manual.rs
+++ b/examples/manual.rs
@@ -71,7 +71,7 @@ fn cors_options() -> CorsOptions {
 
 #[rocket::main]
 async fn main() -> Result<(), Error> {
-    rocket::ignite()
+    rocket::build()
         .mount("/", routes![borrowed, response, owned, owned_options,])
         .mount("/", rocket_cors::catch_all_options_routes()) // mount the catch all routes
         .manage(cors_options().to_cors().expect("To not fail"))

--- a/examples/mix.rs
+++ b/examples/mix.rs
@@ -56,7 +56,7 @@ fn cors_options_all() -> CorsOptions {
 
 #[rocket::main]
 async fn main() -> Result<(), Error> {
-    rocket::ignite()
+    rocket::build()
         .mount("/", routes![app, ping, ping_options,])
         .mount("/", rocket_cors::catch_all_options_routes()) // mount the catch all routes
         .manage(cors_options().to_cors().expect("To not fail"))

--- a/src/fairing.rs
+++ b/src/fairing.rs
@@ -189,7 +189,10 @@ mod tests {
 
     #[rocket::async_test]
     async fn error_route_is_mounted_on_ignite() {
-        let rocket = rocket(make_cors_options()).ignite().await.expect("to ignite");
+        let rocket = rocket(make_cors_options())
+            .ignite()
+            .await
+            .expect("to ignite");
 
         let expected_uri = format!("{}/<status>", CORS_ROOT);
         let error_route = rocket

--- a/src/fairing.rs
+++ b/src/fairing.rs
@@ -1,8 +1,9 @@
 //! Fairing implementation
 
+#[allow(unused_imports)]
 use ::log::{error, info};
 use rocket::http::{self, uri::Origin, Status};
-use rocket::{self, error_, info_, log_, outcome::Outcome, Request};
+use rocket::{self, error_, info_, outcome::Outcome, Request};
 
 use crate::{
     actual_request_response, origin, preflight_response, request_headers, validate, Cors, Error,

--- a/src/fairing.rs
+++ b/src/fairing.rs
@@ -1,7 +1,8 @@
 //! Fairing implementation
 
+use ::log::{error, info};
 use rocket::http::{self, uri::Origin, Status};
-use rocket::{self, error_, info_, outcome::Outcome, Request};
+use rocket::{self, error_, info_, log_, outcome::Outcome, Request};
 
 use crate::{
     actual_request_response, origin, preflight_response, request_headers, validate, Cors, Error,

--- a/src/fairing.rs
+++ b/src/fairing.rs
@@ -1,8 +1,7 @@
 //! Fairing implementation
 
-use ::log::{error, info};
 use rocket::http::{self, uri::Origin, Status};
-use rocket::{self, error_, info_, log_, outcome::Outcome, Request};
+use rocket::{self, error_, info_, outcome::Outcome, Request};
 
 use crate::{
     actual_request_response, origin, preflight_response, request_headers, validate, Cors, Error,

--- a/src/fairing.rs
+++ b/src/fairing.rs
@@ -19,14 +19,14 @@ enum CorsValidation {
 struct FairingErrorRoute {}
 
 #[rocket::async_trait]
-impl rocket::handler::Handler for FairingErrorRoute {
-    async fn handle<'r, 's: 'r>(
-        &'s self,
+impl rocket::route::Handler for FairingErrorRoute {
+    async fn handle<'r>(
+        &self,
         request: &'r Request<'_>,
         _: rocket::Data,
-    ) -> rocket::handler::Outcome<'r> {
+    ) -> rocket::route::Outcome<'r> {
         let status = request
-            .get_param::<u16>(0)
+            .param::<u16>(0)
             .unwrap_or(Ok(0))
             .unwrap_or_else(|e| {
                 error_!("Fairing Error Handling Route error: {:?}", e);
@@ -102,13 +102,13 @@ impl rocket::fairing::Fairing for Cors {
     fn info(&self) -> rocket::fairing::Info {
         rocket::fairing::Info {
             name: "CORS",
-            kind: rocket::fairing::Kind::Attach
+            kind: rocket::fairing::Kind::Ignite
                 | rocket::fairing::Kind::Request
                 | rocket::fairing::Kind::Response,
         }
     }
 
-    async fn on_attach(&self, rocket: rocket::Rocket) -> Result<rocket::Rocket, rocket::Rocket> {
+    async fn on_ignite(&self, rocket: rocket::Rocket<rocket::Build>) -> rocket::fairing::Result {
         Ok(rocket.mount(
             &self.fairing_route_base,
             vec![fairing_route(self.fairing_route_rank)],
@@ -164,8 +164,8 @@ mod tests {
         .expect("Not to fail")
     }
 
-    fn rocket(fairing: Cors) -> Rocket {
-        Rocket::ignite().attach(fairing)
+    fn rocket(fairing: Cors) -> Rocket<rocket::Build> {
+        Rocket::build().attach(fairing)
     }
 
     #[test]
@@ -187,8 +187,8 @@ mod tests {
     }
 
     #[rocket::async_test]
-    async fn error_route_is_mounted_on_attach() {
-        let rocket = rocket(make_cors_options());
+    async fn error_route_is_mounted_on_ignite() {
+        let rocket = rocket(make_cors_options()).ignite().await.expect("to ignite");
 
         let expected_uri = format!("{}/<status>", CORS_ROOT);
         let error_route = rocket

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -134,11 +134,11 @@ impl fmt::Display for Origin {
 }
 
 #[rocket::async_trait]
-impl<'a, 'r> FromRequest<'a, 'r> for Origin {
+impl<'r> FromRequest<'r> for Origin {
     type Error = crate::Error;
 
     async fn from_request(
-        request: &'a rocket::Request<'r>,
+        request: &'r rocket::Request<'_>,
     ) -> request::Outcome<Self, crate::Error> {
         Origin::from_request_sync(request)
     }
@@ -180,11 +180,11 @@ impl FromStr for AccessControlRequestMethod {
 }
 
 #[rocket::async_trait]
-impl<'a, 'r> FromRequest<'a, 'r> for AccessControlRequestMethod {
+impl<'r> FromRequest<'r> for AccessControlRequestMethod {
     type Error = crate::Error;
 
     async fn from_request(
-        request: &'a rocket::Request<'r>,
+        request: &'r rocket::Request<'_>,
     ) -> request::Outcome<Self, crate::Error> {
         AccessControlRequestMethod::from_request_sync(request)
     }
@@ -238,11 +238,11 @@ impl FromStr for AccessControlRequestHeaders {
 }
 
 #[rocket::async_trait]
-impl<'a, 'r> FromRequest<'a, 'r> for AccessControlRequestHeaders {
+impl<'r> FromRequest<'r> for AccessControlRequestHeaders {
     type Error = crate::Error;
 
     async fn from_request(
-        request: &'a rocket::Request<'r>,
+        request: &'r rocket::Request<'_>,
     ) -> request::Outcome<Self, crate::Error> {
         AccessControlRequestHeaders::from_request_sync(request)
     }
@@ -266,7 +266,7 @@ mod tests {
 
     /// Make a client with no routes for unit testing
     fn make_client() -> Client {
-        let rocket = rocket::ignite();
+        let rocket = rocket::build();
         Client::tracked(rocket).expect("valid rocket instance")
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1989,14 +1989,12 @@ fn actual_request_response(options: &Cors, origin: &str) -> Response {
 ///
 /// See the documentation at the [crate root](index.html) for usage information.
 pub fn catch_all_options_routes() -> Vec<rocket::Route> {
-    vec![
-        rocket::Route::ranked(
-            isize::MAX,
-            http::Method::Options,
-            "/<catch_all_options_route..>",
-            CatchAllOptionsRouteHandler {},
-        ),
-    ]
+    vec![rocket::Route::ranked(
+        isize::MAX,
+        http::Method::Options,
+        "/<catch_all_options_route..>",
+        CatchAllOptionsRouteHandler {},
+    )]
 }
 
 /// Handler for the "catch all options route"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,12 +280,13 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 use std::str::FromStr;
 
-use ::log::{debug, error, info};
+
+use ::log::info;
 use regex::RegexSet;
 use rocket::http::{self, Status};
 use rocket::request::{FromRequest, Request};
 use rocket::response;
-use rocket::{debug_, error_, info_, log_, outcome::Outcome, State};
+use rocket::{debug_, error_, info_, outcome::Outcome, State};
 #[cfg(feature = "serialization")]
 use serde_derive::{Deserialize, Serialize};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,12 +280,13 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 use std::str::FromStr;
 
+#[allow(unused_imports)]
 use ::log::{debug, error, info};
 use regex::RegexSet;
 use rocket::http::{self, Status};
 use rocket::request::{FromRequest, Request};
 use rocket::response;
-use rocket::{debug_, error_, info_, log_, outcome::Outcome, State};
+use rocket::{debug_, error_, info_, outcome::Outcome, State};
 #[cfg(feature = "serialization")]
 use serde_derive::{Deserialize, Serialize};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1991,13 +1991,7 @@ fn actual_request_response(options: &Cors, origin: &str) -> Response {
 pub fn catch_all_options_routes() -> Vec<rocket::Route> {
     vec![
         rocket::Route::ranked(
-            isize::max_value(),
-            http::Method::Options,
-            "/",
-            CatchAllOptionsRouteHandler {},
-        ),
-        rocket::Route::ranked(
-            isize::max_value(),
+            isize::MAX,
             http::Method::Options,
             "/<catch_all_options_route..>",
             CatchAllOptionsRouteHandler {},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,13 +280,12 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 use std::str::FromStr;
 
-
-use ::log::info;
+use ::log::{debug, error, info};
 use regex::RegexSet;
 use rocket::http::{self, Status};
 use rocket::request::{FromRequest, Request};
 use rocket::response;
-use rocket::{debug_, error_, info_, outcome::Outcome, State};
+use rocket::{debug_, error_, info_, log_, outcome::Outcome, State};
 #[cfg(feature = "serialization")]
 use serde_derive::{Deserialize, Serialize};
 

--- a/tests/fairing.rs
+++ b/tests/fairing.rs
@@ -36,8 +36,8 @@ fn make_cors() -> Cors {
     .expect("To not fail")
 }
 
-fn rocket() -> rocket::Rocket {
-    rocket::ignite()
+fn rocket() -> rocket::Rocket<rocket::Build> {
+    rocket::build()
         .mount("/", routes![cors, panicking_route])
         .attach(make_cors())
 }

--- a/tests/guard.rs
+++ b/tests/guard.rs
@@ -78,8 +78,8 @@ fn make_cors() -> cors::Cors {
     .expect("To not fail")
 }
 
-fn make_rocket() -> rocket::Rocket {
-    rocket::ignite()
+fn make_rocket() -> rocket::Rocket<rocket::Build> {
+    rocket::build()
         .mount("/", routes![cors_responder, panicking_route])
         .mount(
             "/",

--- a/tests/headers.rs
+++ b/tests/headers.rs
@@ -32,7 +32,7 @@ fn request_headers(
 /// Tests that all the request headers are parsed correcly in a HTTP request
 #[test]
 fn request_headers_round_trip_smoke_test() {
-    let rocket = rocket::ignite().mount("/", routes![request_headers]);
+    let rocket = rocket::build().mount("/", routes![request_headers]);
     let client = Client::tracked(rocket).expect("A valid Rocket client");
 
     let origin_header = Header::new(ORIGIN.as_str(), "https://foo.bar.xyz");

--- a/tests/manual.rs
+++ b/tests/manual.rs
@@ -95,8 +95,8 @@ fn make_different_cors_options() -> CorsOptions {
     }
 }
 
-fn rocket() -> rocket::Rocket {
-    rocket::ignite()
+fn rocket() -> rocket::Rocket<rocket::Build> {
+    rocket::build()
         .mount("/", routes![cors, panicking_route])
         .mount("/", routes![owned, owned_options])
         .mount("/", catch_all_options_routes()) // mount the catch all routes

--- a/tests/mix.rs
+++ b/tests/mix.rs
@@ -61,8 +61,8 @@ fn cors_options_all() -> CorsOptions {
     Default::default()
 }
 
-fn rocket() -> rocket::Rocket {
-    rocket::ignite()
+fn rocket() -> rocket::Rocket<rocket::Build> {
+    rocket::build()
         .mount("/", routes![app, ping, ping_options,])
         .mount("/", rocket_cors::catch_all_options_routes()) // mount the catch all routes
         .manage(cors_options().to_cors().expect("Not to fail"))


### PR DESCRIPTION
Because of some change in rocket's master branch, currently this library cannot be use with rocket's master branch. This PR update the library to be compatible with latest rocket's master branch.

### Changes
- Rocket phase have changed to Build -> Ignite -> Orbit
  - `rocket::ignite()`(which was previously the first phase) are now replaced by `rocket::build()`
  - `rocket::Rocket` now have one type parameter signifying the phase
- Replace fairing's `on_attach()` with `on_ignite()` 
  - some of fairing's test are change to test when rocket are on ignite phase.
- Replace `rocket::handler` with `rocket::route`
  -  `rocket::route::Handler` don't have the same lifetime signature as (now removed)`rocket::handler::Handler`
- `rocket::log_` are removed
- Replace `rocket::Request::get_param()` with `rocket::Request::param()`
- Multiple segment now matched empty path (previously the route `"/<p..>"` won't match `"/"` but now it will). this change cause the routes returned from `catch_all_options_routes()` to collide so I remove the empty route.