### PR TITLE
Update to latest Rocket master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serialization = ["serde", "serde_derive", "unicase_serde"]
 
 [dependencies]
 regex = "1.1"
-rocket = { rev="801e04bd5369eb39e126c75f6d11e1e9597304d8", git = "https://github.com/SergioBenitez/Rocket.git", default-features = false }
+rocket = { rev="1f1976f8bf8531daf4ac596d83ea7ad589dd7368", git = "https://github.com/SergioBenitez/Rocket.git", default-features = false }
 log = "0.4"
 unicase = "2.0"
 url = "2.1.0"

--- a/examples/guard.rs
+++ b/examples/guard.rs
@@ -1,8 +1,6 @@
 use std::error::Error;
-use std::io::Cursor;
 
 use rocket::http::Method;
-use rocket::Response;
 use rocket::{get, options, routes};
 use rocket_cors::{AllowedHeaders, AllowedOrigins, Guard, Responder};
 
@@ -10,15 +8,6 @@ use rocket_cors::{AllowedHeaders, AllowedOrigins, Guard, Responder};
 #[get("/")]
 fn responder(cors: Guard<'_>) -> Responder<'_, '_, &str> {
     cors.responder("Hello CORS!")
-}
-
-/// Using a `Response` instead of a `Responder`. You generally won't have to do this.
-#[get("/response")]
-fn response(cors: Guard<'_>) -> Response<'_> {
-    let mut response = Response::new();
-    let body = "Hello CORS!";
-    response.set_sized_body(body.len(), Cursor::new(body));
-    cors.response(response)
 }
 
 /// Manually mount an OPTIONS route for your own handling
@@ -48,7 +37,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     .to_cors()?;
 
     rocket::build()
-        .mount("/", routes![responder, response])
+        .mount("/", routes![responder])
         // Mount the routes to catch all the OPTIONS pre-flight requests
         .mount("/", rocket_cors::catch_all_options_routes())
         // You can also manually mount an OPTIONS route that will be used instead

--- a/src/fairing.rs
+++ b/src/fairing.rs
@@ -93,7 +93,7 @@ fn on_response_wrapper(
             request
         );
         response.set_status(Status::NoContent);
-        let _ = response.take_body();
+        let _ = response.body();
     }
     Ok(())
 }
@@ -134,7 +134,7 @@ impl rocket::fairing::Fairing for Cors {
         if let Err(err) = on_response_wrapper(self, request, response) {
             error_!("Fairings on_response error: {}\nMost likely a bug", err);
             response.set_status(Status::InternalServerError);
-            let _ = response.take_body();
+            let _ = response.body();
         }
     }
 }

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -124,7 +124,7 @@ impl FromStr for Origin {
 }
 
 impl fmt::Display for Origin {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Origin::Null => write!(f, "null"),
             Origin::Parsed(ref parsed) => write!(f, "{}", parsed.ascii_serialization()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,7 +353,7 @@ impl Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::MissingOrigin => write!(
                 f,
@@ -1521,7 +1521,7 @@ impl<'r> FromRequest<'r> for Guard<'r> {
     type Error = Error;
 
     async fn from_request(request: &'r Request<'_>) -> rocket::request::Outcome<Self, Self::Error> {
-        let options = match request.guard::<State<'_, Cors>>().await {
+        let options = match request.guard::<&State<Cors>>().await {
             Outcome::Success(options) => options,
             _ => {
                 let error = Error::MissingCorsInRocketState;
@@ -2523,8 +2523,7 @@ mod tests {
         let response = Response::new();
         let response = response.response(response::Response::new());
 
-        let headers: Vec<_> = response.headers().iter().collect();
-        assert_eq!(headers.len(), 0);
+        assert_eq!(response.headers().iter().count(), 0);
     }
 
     #[test]

--- a/tests/manual.rs
+++ b/tests/manual.rs
@@ -16,14 +16,14 @@ static ACCESS_CONTROL_REQUEST_HEADERS: hyper::HeaderName =
 
 /// Using a borrowed `Cors`
 #[get("/")]
-fn cors(options: State<'_, Cors>) -> impl Responder<'_, '_> {
+fn cors(options: &State<Cors>) -> impl Responder<'_, '_> {
     options
         .inner()
         .respond_borrowed(|guard| guard.responder("Hello CORS"))
 }
 
 #[get("/panic")]
-fn panicking_route(options: State<'_, Cors>) -> impl Responder<'_, '_> {
+fn panicking_route(options: &State<Cors>) -> impl Responder<'_, '_> {
     options.inner().respond_borrowed(|_| {
         panic!("This route will panic");
     })
@@ -50,7 +50,7 @@ fn owned<'r, 'o: 'r>() -> impl Responder<'r, 'o> {
 /// `Responder` with String
 #[get("/")]
 #[allow(dead_code)]
-fn responder_string(options: State<'_, Cors>) -> impl Responder<'_, '_> {
+fn responder_string(options: &State<Cors>) -> impl Responder<'_, '_> {
     options
         .inner()
         .respond_borrowed(|guard| guard.responder("Hello CORS".to_string()))
@@ -61,8 +61,8 @@ struct TestState;
 #[get("/")]
 #[allow(dead_code)]
 fn borrow<'r, 'o: 'r>(
-    options: State<'r, Cors>,
-    test_state: State<'r, TestState>,
+    options: &'r State<Cors>,
+    test_state: &'r State<TestState>,
 ) -> impl Responder<'r, 'o> {
     let borrow = test_state.inner();
     options.inner().respond_borrowed(move |guard| {


### PR DESCRIPTION
- Update all instances of `State<T>` to borrow and drop anonymous lifetime
- Remove examples showing returning a `Response` instead of a `Responder`
  since `Response` no longer implements `Responder`