### PR TITLE
Resolve Tokio Dependency conflicy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serialization = ["serde", "serde_derive", "unicase_serde"]
 
 [dependencies]
 regex = "1.1"
-rocket = { rev="1f1976f8bf8531daf4ac596d83ea7ad589dd7368", git = "https://github.com/SergioBenitez/Rocket.git", default-features = false }
+rocket = { rev="3a3d0ce51850368880fa3565f9fc96f7b4dcf06b", git = "https://github.com/SergioBenitez/Rocket.git", default-features = false }
 log = "0.4"
 unicase = "2.0"
 url = "2.1.0"


### PR DESCRIPTION
Pull request #91 updated to a version of Rocket which specified a tokio version <= 1.6.0
More recent rocket commits to master have since specified v1.6.1.

This causes version conflicts when attempting to install rocket-cors with the latest version of Rocket.
This fix pushes the version of rocket specified to after the tokio version change, fixing the conflict.
