### PR TITLE
Update lib.rs and README for nightly req and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,30 +10,16 @@ Cross-origin resource sharing (CORS) for [Rocket](https://rocket.rs/) applicatio
 
 ## Requirements
 
-- Nightly Rust
 - Rocket >= 0.4
 
 If you are using Rocket 0.3, use the `0.3.0` version of this crate.
-
-There is a minimum version of Rust nightly required. This is usually higher than whatever
-Rocket requires plus more if the dependent crates require other features.
-
-### Nightly Rust
-
-Rocket requires nightly Rust. You should probably install Rust with
-[rustup](https://www.rustup.rs/), then override the code directory to use nightly instead of stable.
-See
-[installation instructions](https://rocket.rs/guide/getting-started/#installing-rust).
-
-In particular, `rocket_cors` is currently targetted for the latest `nightly`. Older nightlies might
-work, but they are subject to the minimum that Rocket sets.
 
 ## Installation
 
 Add the following to Cargo.toml:
 
 ```toml
-rocket_cors = "0.5.1"
+rocket_cors = "0.5.2"
 ```
 
 To use the latest `master` branch, for example:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,27 +9,16 @@ Cross-origin resource sharing (CORS) for [Rocket](https://rocket.rs/) applicatio
 
 ## Requirements
 
-- Nightly Rust
 - Rocket >= 0.4
 
 If you are using Rocket 0.3, use the `0.3.0` version of this crate.
-
-### Nightly Rust
-
-Rocket requires nightly Rust. You should probably install Rust with
-[rustup](https://www.rustup.rs/), then override the code directory to use nightly instead of
-stable. See
-[installation instructions](https://rocket.rs/guide/getting-started/#installing-rust).
-
-In particular, `rocket_cors` is currently targetted for the latest `nightly`. Older nightlies
-might work, but they are subject to the minimum that Rocket sets.
 
 ## Installation
 
 Add the following to Cargo.toml:
 
 ```toml
-rocket_cors = "0.5.1"
+rocket_cors = "0.5.2"
 ```
 
 To use the latest `master` branch, for example:
@@ -45,7 +34,7 @@ the [`CorsOptions`] struct that is described below. If you would like to disable
 change your `Cargo.toml` to:
 
 ```toml
-rocket_cors = { version = "0.5.1", default-features = false }
+rocket_cors = { version = "0.5.2", default-features = false }
 ```
 
 ## Usage


### PR DESCRIPTION
This commit removes mentions about requiring nightly and changes the
snippets to match the current Cargo.toml version.