### PR TITLE
Responder lifetime cannot be infered

### DIFF
--- a/examples/guard.rs
+++ b/examples/guard.rs
@@ -6,19 +6,19 @@ use rocket_cors::{AllowedHeaders, AllowedOrigins, Guard, Responder};
 
 /// Using a `Responder` -- the usual way you would use this
 #[get("/")]
-fn responder(cors: Guard<'_>) -> Responder<'_, '_, &str> {
+fn responder(cors: Guard<'_>) -> Responder<&str> {
     cors.responder("Hello CORS!")
 }
 
 /// Manually mount an OPTIONS route for your own handling
 #[options("/manual")]
-fn manual_options(cors: Guard<'_>) -> Responder<'_, '_, &str> {
+fn manual_options(cors: Guard<'_>) -> Responder<&str> {
     cors.responder("Manual OPTIONS preflight handling")
 }
 
 /// Manually mount an OPTIONS route for your own handling
 #[get("/manual")]
-fn manual(cors: Guard<'_>) -> Responder<'_, '_, &str> {
+fn manual(cors: Guard<'_>) -> Responder<&str> {
     cors.responder("Manual OPTIONS preflight handling")
 }
 

--- a/examples/mix.rs
+++ b/examples/mix.rs
@@ -11,7 +11,7 @@ use rocket_cors::{AllowedHeaders, AllowedOrigins, CorsOptions, Guard};
 
 /// The "usual" app route
 #[get("/")]
-fn app(cors: Guard<'_>) -> rocket_cors::Responder<'_, '_, &str> {
+fn app(cors: Guard<'_>) -> rocket_cors::Responder<&str> {
     cors.responder("Hello CORS!")
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1371,7 +1371,7 @@ impl Response {
     pub fn responder<'r, 'o: 'r, R: response::Responder<'r, 'o>>(
         self,
         responder: R,
-    ) -> Responder<'r, 'o, R> {
+    ) -> Responder<R> {
         Responder::new(responder, self)
     }
 
@@ -1492,7 +1492,7 @@ impl<'r, 'o: 'r> Guard<'r> {
 
     /// Consumes the Guard and return  a `Responder` that wraps a
     /// provided `rocket:response::Responder` with CORS headers
-    pub fn responder<R: response::Responder<'r, 'o>>(self, responder: R) -> Responder<'r, 'o, R> {
+    pub fn responder<R: response::Responder<'r, 'o>>(self, responder: R) -> Responder<R> {
         self.response.responder(responder)
     }
 
@@ -1542,18 +1542,17 @@ impl<'r> FromRequest<'r> for Guard<'r> {
 ///
 /// See the documentation at the [crate root](index.html) for usage information.
 #[derive(Debug)]
-pub struct Responder<'r, 'o, R> {
+pub struct Responder<R> {
     responder: R,
     cors_response: Response,
-    marker: PhantomData<dyn response::Responder<'r, 'o>>,
 }
 
-impl<'r, 'o: 'r, R: response::Responder<'r, 'o>> Responder<'r, 'o, R> {
+impl<'r, 'o: 'r, R: response::Responder<'r, 'o>> Responder<R> {
     fn new(responder: R, cors_response: Response) -> Self {
         Self {
             responder,
             cors_response,
-            marker: PhantomData,
+            // marker: PhantomData,
         }
     }
 
@@ -1565,9 +1564,7 @@ impl<'r, 'o: 'r, R: response::Responder<'r, 'o>> Responder<'r, 'o, R> {
     }
 }
 
-impl<'r, 'o: 'r, R: response::Responder<'r, 'o>> response::Responder<'r, 'o>
-    for Responder<'r, 'o, R>
-{
+impl<'r, 'o: 'r, R: response::Responder<'r, 'o>> response::Responder<'r, 'o> for Responder<R> {
     fn respond_to(self, request: &'r Request<'_>) -> response::Result<'o> {
         self.respond(request)
     }

--- a/tests/guard.rs
+++ b/tests/guard.rs
@@ -15,46 +15,43 @@ static ACCESS_CONTROL_REQUEST_HEADERS: hyper::HeaderName =
     hyper::header::ACCESS_CONTROL_REQUEST_HEADERS;
 
 #[get("/")]
-fn cors_responder(cors: cors::Guard<'_>) -> cors::Responder<'_, '_, &str> {
+fn cors_responder(cors: cors::Guard<'_>) -> cors::Responder<&str> {
     cors.responder("Hello CORS")
 }
 
 #[get("/panic")]
-fn panicking_route(_cors: cors::Guard<'_>) -> cors::Responder<'_, '_, &str> {
+fn panicking_route(_cors: cors::Guard<'_>) -> cors::Responder<&str> {
     panic!("This route will panic");
 }
 
 /// Manually specify our own OPTIONS route
 #[options("/manual")]
-fn cors_manual_options(cors: cors::Guard<'_>) -> cors::Responder<'_, '_, &str> {
+fn cors_manual_options(cors: cors::Guard<'_>) -> cors::Responder<&str> {
     cors.responder("Manual CORS Preflight")
 }
 
 /// Manually specify our own OPTIONS route
 #[get("/manual")]
-fn cors_manual(cors: cors::Guard<'_>) -> cors::Responder<'_, '_, &str> {
+fn cors_manual(cors: cors::Guard<'_>) -> cors::Responder<&str> {
     cors.responder("Hello CORS")
 }
 
 /// `Responder` with String
 #[get("/responder/string")]
-fn responder_string(cors: cors::Guard<'_>) -> cors::Responder<'_, 'static, String> {
+fn responder_string(cors: cors::Guard<'_>) -> cors::Responder<String> {
     cors.responder("Hello CORS".to_string())
 }
 
 /// `Responder` with 'static ()
 #[get("/responder/unit")]
-fn responder_unit(cors: cors::Guard<'_>) -> cors::Responder<'_, 'static, ()> {
+fn responder_unit(cors: cors::Guard<'_>) -> cors::Responder<()> {
     cors.responder(())
 }
 
 struct SomeState;
 /// Borrow `SomeState` from Rocket
 #[get("/state")]
-fn state<'r, 'o: 'r>(
-    cors: cors::Guard<'r>,
-    _state: &State<SomeState>,
-) -> cors::Responder<'r, 'o, &'r str> {
+fn state<'r, 'o: 'r>(cors: cors::Guard<'r>, _state: &State<SomeState>) -> cors::Responder<&'r str> {
     cors.responder("hmm")
 }
 

--- a/tests/guard.rs
+++ b/tests/guard.rs
@@ -51,7 +51,7 @@ fn responder_unit(cors: cors::Guard<'_>) -> cors::Responder<()> {
 struct SomeState;
 /// Borrow `SomeState` from Rocket
 #[get("/state")]
-fn state<'r, 'o: 'r>(cors: cors::Guard<'r>, _state: &State<SomeState>) -> cors::Responder<&'r str> {
+fn state<'r>(cors: cors::Guard<'r>, _state: &State<SomeState>) -> cors::Responder<&'r str> {
     cors.responder("hmm")
 }
 

--- a/tests/mix.rs
+++ b/tests/mix.rs
@@ -18,7 +18,7 @@ static ACCESS_CONTROL_REQUEST_HEADERS: hyper::HeaderName =
 
 /// The "usual" app route
 #[get("/")]
-fn app(cors: Guard<'_>) -> rocket_cors::Responder<'_, '_, &str> {
+fn app(cors: Guard<'_>) -> rocket_cors::Responder<&str> {
     cors.responder("Hello CORS!")
 }
 


### PR DESCRIPTION
[This stackoverflow question](https://stackoverflow.com/questions/68192505/rocket-cors-how-to-return-string-with-request-guard) shows that it's not sufficient to have elided lifetimes on `Responder` because these aren't correctly infered when the wrapped responder is less restrictive. 

The root cause of this is the `PhantomData` holding `'r` and `'o` inside `Responder`. These aren't required because the bounds on the impl blocks are sufficient to provide the correct semantics, and `R` will already hold these bounds implicitly.

This is gonna be a breaking change, but it should make it easier to use in the long term. That is unless you can think of any cases that this doesn't handle? 