### PR TITLE
Drop body from response to preflight request

### DIFF
--- a/src/fairing.rs
+++ b/src/fairing.rs
@@ -93,7 +93,7 @@ fn on_response_wrapper(
             request
         );
         response.set_status(Status::NoContent);
-        let _ = response.body();
+        let _ = response.body_mut().take();
     }
     Ok(())
 }


### PR DESCRIPTION
`Response::body()` has no side effects.
To drop the body, we have to use `body_mut().take()`.

Originally, rocket_cors called `Response::take_body()` which was in rocket v0.4.
It has been replaced with `Response::body()` in [this patch](https://github.com/lawliet89/rocket_cors/commit/0b2d3e80b13d21162bd240f911e304a258ec3fb4#diff-5123f34e46e91dd8a37c00eba3092c0036b6374267317a73db1507ce0eb5453aL137) acidentially.
However, it is absent in v0.5.0-rc, `body_mut().take()` should be used instead.
