### PR TITLE
Fix rustdoc lint drift

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,7 +250,7 @@ See the [example](https://github.com/lawliet89/rocket_cors/blob/master/examples/
     missing_debug_implementations,
     unknown_lints,
     unsafe_code,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 


### PR DESCRIPTION
The lint name drifted upstream and was failing builds