### PR TITLE
feat: update rust edition from 2018 to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/lawliet89/rocket_cors"
 documentation = "https://docs.rs/rocket_cors/"
 keywords = ["rocket", "cors"]
 categories = ["web-programming"]
-edition = "2018"
+edition = "2021"
 
 [badges]
 travis-ci = { repository = "lawliet89/rocket_cors" }

--- a/src/fairing.rs
+++ b/src/fairing.rs
@@ -26,6 +26,7 @@ impl rocket::route::Handler for FairingErrorRoute {
         request: &'r Request<'_>,
         _: rocket::Data<'r>,
     ) -> rocket::route::Outcome<'r> {
+        let _ = &__arg2;
         let status = request
             .param::<u16>(0)
             .unwrap_or(Ok(0))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1994,6 +1994,7 @@ impl rocket::route::Handler for CatchAllOptionsRouteHandler {
         request: &'r Request<'_>,
         _: rocket::Data<'r>,
     ) -> rocket::route::Outcome<'r> {
+        let _ = &__arg2;
         let guard: Guard<'_> = match request.guard().await {
             Outcome::Success(guard) => guard,
             Outcome::Failure((status, _)) => return rocket::route::Outcome::failure(status),


### PR DESCRIPTION
- Ran `cargo fix —edition`
- Changed `edition` in `Cargo.toml` to __2021__
- Tests were all ok

Would you mind updating the crate on crates.io? The last release was in march, since some commits were made which are important for devs using the rocket rc