### PR TITLE
security patch: regex crate CVE-2022-24713

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default = ["serialization"]
 serialization = ["serde", "serde_derive", "unicase_serde"]
 
 [dependencies]
-regex = "1.1"
+regex = "1.5.5"
 rocket = { version = "0.5.0-rc.1", default-features = false }
 log = "0.4"
 unicase = "2.0"


### PR DESCRIPTION
More information at https://blog.rust-lang.org/2022/03/08/cve-2022-24713.html