### PR TITLE
remove not found __arg2

### DIFF
--- a/src/fairing.rs
+++ b/src/fairing.rs
@@ -26,7 +26,6 @@ impl rocket::route::Handler for FairingErrorRoute {
         request: &'r Request<'_>,
         _: rocket::Data<'r>,
     ) -> rocket::route::Outcome<'r> {
-        let _ = &__arg2;
         let status = request
             .param::<u16>(0)
             .unwrap_or(Ok(0))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2003,7 +2003,6 @@ impl rocket::route::Handler for CatchAllOptionsRouteHandler {
         request: &'r Request<'_>,
         _: rocket::Data<'r>,
     ) -> rocket::route::Outcome<'r> {
-        let _ = &__arg2;
         let guard: Guard<'_> = match request.guard().await {
             Outcome::Success(guard) => guard,
             Outcome::Failure((status, _)) => return rocket::route::Outcome::failure(status),


### PR DESCRIPTION
Fix compilation error with `rocket_cors ="0.6.0-alpha1"` and `rocket = "0.5.0-rc.2"` on `rustc 1.61.0`.

```bash
Compiling rocket_cors v0.6.0-alpha1
error[E0425]: cannot find value `__arg2` in this scope
  --> /home/_/.cargo/registry/src/github.com-1ecc6299db9ec823/rocket_cors-0.6.0-alpha1/src/fairing.rs:29:18
   |
29 |         let _ = &__arg2;
   |                  ^^^^^^ not found in this scope

error[E0425]: cannot find value `__arg2` in this scope
    --> /home/_/.cargo/registry/src/github.com-1ecc6299db9ec823/rocket_cors-0.6.0-alpha1/src/lib.rs:1997:18
     |
1997 |         let _ = &__arg2;
     |                  ^^^^^^ not found in this scope

For more information about this error, try `rustc --explain E0425`.
error: could not compile `rocket_cors` due to 2 previous errors
```