### PR TITLE
Update to work with latest Rocket RC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ rocket = { version = "0.5.0-rc.1", default-features = false }
 log = "0.4"
 unicase = "2.0"
 url = "2.1.0"
+http = "0.2"
 
 # Optional dependencies that are activated by the various features
 serde = { version = "1.0", optional = true }

--- a/examples/fairing.rs
+++ b/examples/fairing.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
     .to_cors()?;
 
-    rocket::build()
+    let _ = rocket::build()
         .mount("/", routes![cors])
         .attach(cors)
         .launch()

--- a/examples/guard.rs
+++ b/examples/guard.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
     .to_cors()?;
 
-    rocket::build()
+    let _ = rocket::build()
         .mount("/", routes![responder])
         // Mount the routes to catch all the OPTIONS pre-flight requests
         .mount("/", rocket_cors::catch_all_options_routes())

--- a/examples/manual.rs
+++ b/examples/manual.rs
@@ -55,10 +55,12 @@ fn cors_options() -> CorsOptions {
 
 #[rocket::main]
 async fn main() -> Result<(), Error> {
-    rocket::build()
+    let _ = rocket::build()
         .mount("/", routes![borrowed, owned, owned_options,])
         .mount("/", rocket_cors::catch_all_options_routes()) // mount the catch all routes
         .manage(cors_options().to_cors().expect("To not fail"))
-        .launch()
-        .await
+        .ignite()
+        .await?;
+
+    Ok(())
 }

--- a/examples/mix.rs
+++ b/examples/mix.rs
@@ -56,10 +56,12 @@ fn cors_options_all() -> CorsOptions {
 
 #[rocket::main]
 async fn main() -> Result<(), Error> {
-    rocket::build()
+    let _ = rocket::build()
         .mount("/", routes![app, ping, ping_options,])
         .mount("/", rocket_cors::catch_all_options_routes()) // mount the catch all routes
         .manage(cors_options().to_cors().expect("To not fail"))
         .launch()
-        .await
+        .await?;
+
+    Ok(())
 }

--- a/src/fairing.rs
+++ b/src/fairing.rs
@@ -26,7 +26,6 @@ impl rocket::route::Handler for FairingErrorRoute {
         request: &'r Request<'_>,
         _: rocket::Data<'r>,
     ) -> rocket::route::Outcome<'r> {
-        let _ = &__arg2;
         let status = request
             .param::<u16>(0)
             .unwrap_or(Ok(0))

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -39,7 +39,7 @@ impl<'a> From<&'a str> for HeaderFieldName {
     }
 }
 
-impl<'a> From<String> for HeaderFieldName {
+impl From<String> for HeaderFieldName {
     fn from(s: String) -> Self {
         HeaderFieldName(From::from(s))
     }

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -256,10 +256,10 @@ mod tests {
     use rocket::http::Header;
     use rocket::local::blocking::Client;
 
-    static ORIGIN: hyper::HeaderName = hyper::header::ORIGIN;
-    static ACCESS_CONTROL_REQUEST_METHOD: hyper::HeaderName =
+    static ORIGIN: http::header::HeaderName = hyper::header::ORIGIN;
+    static ACCESS_CONTROL_REQUEST_METHOD: http::header::HeaderName =
         hyper::header::ACCESS_CONTROL_REQUEST_METHOD;
-    static ACCESS_CONTROL_REQUEST_HEADERS: hyper::HeaderName =
+    static ACCESS_CONTROL_REQUEST_HEADERS: http::header::HeaderName =
         hyper::header::ACCESS_CONTROL_REQUEST_HEADERS;
 
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2557,7 +2557,7 @@ mod tests {
             .is_none());
     }
 
-    #[derive(Debug, PartialEq)]
+    #[derive(Debug, Eq, PartialEq)]
     #[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
     struct MethodTest {
         method: crate::Method,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2003,7 +2003,6 @@ impl rocket::route::Handler for CatchAllOptionsRouteHandler {
         request: &'r Request<'_>,
         _: rocket::Data<'r>,
     ) -> rocket::route::Outcome<'r> {
-        let _ = &__arg2;
         let guard: Guard<'_> = match request.guard().await {
             Outcome::Success(guard) => guard,
             Outcome::Failure((status, _)) => return rocket::route::Outcome::failure(status),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2030,10 +2030,10 @@ mod tests {
     use super::*;
     use crate::http::Method;
 
-    static ORIGIN: hyper::HeaderName = hyper::header::ORIGIN;
-    static ACCESS_CONTROL_REQUEST_METHOD: hyper::HeaderName =
+    static ORIGIN: ::http::header::HeaderName = hyper::header::ORIGIN;
+    static ACCESS_CONTROL_REQUEST_METHOD: ::http::header::HeaderName =
         hyper::header::ACCESS_CONTROL_REQUEST_METHOD;
-    static ACCESS_CONTROL_REQUEST_HEADERS: hyper::HeaderName =
+    static ACCESS_CONTROL_REQUEST_HEADERS: ::http::header::HeaderName =
         hyper::header::ACCESS_CONTROL_REQUEST_HEADERS;
 
     fn to_parsed_origin<S: AsRef<str>>(origin: S) -> Result<Origin, Error> {

--- a/tests/fairing.rs
+++ b/tests/fairing.rs
@@ -6,10 +6,10 @@ use rocket::local::blocking::Client;
 use rocket::{get, routes};
 use rocket_cors::*;
 
-static ORIGIN: hyper::HeaderName = hyper::header::ORIGIN;
-static ACCESS_CONTROL_REQUEST_METHOD: hyper::HeaderName =
+static ORIGIN: http::header::HeaderName = hyper::header::ORIGIN;
+static ACCESS_CONTROL_REQUEST_METHOD: http::header::HeaderName =
     hyper::header::ACCESS_CONTROL_REQUEST_METHOD;
-static ACCESS_CONTROL_REQUEST_HEADERS: hyper::HeaderName =
+static ACCESS_CONTROL_REQUEST_HEADERS: http::header::HeaderName =
     hyper::header::ACCESS_CONTROL_REQUEST_HEADERS;
 
 #[get("/")]

--- a/tests/guard.rs
+++ b/tests/guard.rs
@@ -8,10 +8,10 @@ use rocket::local::blocking::Client;
 use rocket::State;
 use rocket::{get, options, routes};
 
-static ORIGIN: hyper::HeaderName = hyper::header::ORIGIN;
-static ACCESS_CONTROL_REQUEST_METHOD: hyper::HeaderName =
+static ORIGIN: http::header::HeaderName = hyper::header::ORIGIN;
+static ACCESS_CONTROL_REQUEST_METHOD: http::header::HeaderName =
     hyper::header::ACCESS_CONTROL_REQUEST_METHOD;
-static ACCESS_CONTROL_REQUEST_HEADERS: hyper::HeaderName =
+static ACCESS_CONTROL_REQUEST_HEADERS: http::header::HeaderName =
     hyper::header::ACCESS_CONTROL_REQUEST_HEADERS;
 
 #[get("/")]

--- a/tests/headers.rs
+++ b/tests/headers.rs
@@ -7,10 +7,10 @@ use rocket::local::blocking::Client;
 use rocket::{get, routes};
 use rocket_cors::headers::*;
 
-static ORIGIN: hyper::HeaderName = hyper::header::ORIGIN;
-static ACCESS_CONTROL_REQUEST_METHOD: hyper::HeaderName =
+static ORIGIN: http::header::HeaderName = hyper::header::ORIGIN;
+static ACCESS_CONTROL_REQUEST_METHOD: http::header::HeaderName =
     hyper::header::ACCESS_CONTROL_REQUEST_METHOD;
-static ACCESS_CONTROL_REQUEST_HEADERS: hyper::HeaderName =
+static ACCESS_CONTROL_REQUEST_HEADERS: http::header::HeaderName =
     hyper::header::ACCESS_CONTROL_REQUEST_HEADERS;
 
 #[get("/request_headers")]

--- a/tests/manual.rs
+++ b/tests/manual.rs
@@ -8,10 +8,10 @@ use rocket::State;
 use rocket::{get, options, routes};
 use rocket_cors::*;
 
-static ORIGIN: hyper::HeaderName = hyper::header::ORIGIN;
-static ACCESS_CONTROL_REQUEST_METHOD: hyper::HeaderName =
+static ORIGIN: http::header::HeaderName = hyper::header::ORIGIN;
+static ACCESS_CONTROL_REQUEST_METHOD: http::header::HeaderName =
     hyper::header::ACCESS_CONTROL_REQUEST_METHOD;
-static ACCESS_CONTROL_REQUEST_HEADERS: hyper::HeaderName =
+static ACCESS_CONTROL_REQUEST_HEADERS: http::header::HeaderName =
     hyper::header::ACCESS_CONTROL_REQUEST_HEADERS;
 
 /// Using a borrowed `Cors`

--- a/tests/mix.rs
+++ b/tests/mix.rs
@@ -10,10 +10,10 @@ use rocket::{get, options, routes};
 
 use rocket_cors::{AllowedHeaders, AllowedOrigins, CorsOptions, Guard};
 
-static ORIGIN: hyper::HeaderName = hyper::header::ORIGIN;
-static ACCESS_CONTROL_REQUEST_METHOD: hyper::HeaderName =
+static ORIGIN: http::header::HeaderName = hyper::header::ORIGIN;
+static ACCESS_CONTROL_REQUEST_METHOD: http::header::HeaderName =
     hyper::header::ACCESS_CONTROL_REQUEST_METHOD;
-static ACCESS_CONTROL_REQUEST_HEADERS: hyper::HeaderName =
+static ACCESS_CONTROL_REQUEST_HEADERS: http::header::HeaderName =
     hyper::header::ACCESS_CONTROL_REQUEST_HEADERS;
 
 /// The "usual" app route


### PR DESCRIPTION
The following changes were made:
- Satisfying the `#[must_use]` annotation on the `Rocket` struct where
  necessary (mostly in test code)
- Adding the `http` crate for the `HeaderName` type
    - Rocket no longer exports all of `hyper` or `http`
      indescriminately, so we have to be more mindful of types from
      either crate that we require. Thus, this commit adds the `http`
      crate to satisfy the requirement.
- Updated tests to properly return a result from a launched `Rocket`