### PR TITLE
Bump Rocket version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serialization = ["serde", "serde_derive", "unicase_serde"]
 
 [dependencies]
 regex = "1.5.5"
-rocket = { version = "0.5.0-rc.1", default-features = false }
+rocket = { version = "0.5.0-rc.2", default-features = false }
 log = "0.4"
 unicase = "2.0"
 url = "2.1.0"


### PR DESCRIPTION
There were apparently changes to use the new Rocket version, but it didn't actually bump the version. This change fixes that.